### PR TITLE
DT-5901 Export Browser and OperatingSystem classes

### DIFF
--- a/lib/platform_detect.dart
+++ b/lib/platform_detect.dart
@@ -9,6 +9,9 @@ import 'package:platform_detect/src/browser.dart';
 import 'package:platform_detect/src/navigator.dart';
 import 'package:platform_detect/src/operating_system.dart';
 
+export 'src/browser.dart';
+export 'src/operating_system.dart';
+
 Browser _browser;
 
 /// Current browser info


### PR DESCRIPTION
### Problem / Feature

`browser` and `operatingSystem` getters return objects of types that are not exported.
### Solution

Export `Browser` and `OperatingSystem` classes.
### What To Test

Attempt to use `Browser` and `OperatingSystem` classes in an app which consumes `platform-detect`
### Reviewers

@travissanderson-wf @dustyholmes-wf 
