### PR TITLE
Add license text to distributed files

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2015 Workiva Inc.
+Copyright 2017 Workiva Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/lib/platform_detect.dart
+++ b/lib/platform_detect.dart
@@ -1,3 +1,17 @@
+// Copyright 2017 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /// Enables detection of browser type and version and operating system
 ///
 /// Use browser.isChrome or operatingSystem.isMac

--- a/lib/src/browser.dart
+++ b/lib/src/browser.dart
@@ -1,3 +1,17 @@
+// Copyright 2017 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 library platform_detect.browser;
 
 import 'package:pub_semver/pub_semver.dart';

--- a/lib/src/navigator.dart
+++ b/lib/src/navigator.dart
@@ -1,3 +1,17 @@
+// Copyright 2017 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 library platform_detect.navigator;
 
 /// Abstraction over window.navigator so we can run tests in the VM

--- a/lib/src/operating_system.dart
+++ b/lib/src/operating_system.dart
@@ -1,3 +1,17 @@
+// Copyright 2017 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 library platform_detect.operating_system;
 
 import 'package:platform_detect/src/navigator.dart';


### PR DESCRIPTION
# Ultimate Problem

As an open source project, the distributed source files should begin with the license text.

# Solution

Add the license text to the files that will be distributed via pub.

# How to +10/QA

Verify that all src files contain the license text.