### PR TITLE
Publish to pub.dartlang.org

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,8 +3,7 @@ description: A lightweight library for detecting the running browser and OS
 version: 1.1.0
 author: Workiva Client Platform Team <team-clientplatform@workiva.com>
 homepage: https://github.com/Workiva/platform_detect
-documentation: https://docs.workiva.org/platform_detect/latest/
-publish_to: https://pub.workiva.org
+documentation: https://www.dartdocs.org/documentation/platform_detect/latest
 
 environment:
   sdk: ">=1.12.1 <2.0.0"


### PR DESCRIPTION
# Ultimate Problem

Now that this package is open source we'd like to upload it to pub.dartlang.org.

# Solution

Remove the configuration that specified a private pub server to publish to.

# How to +10/QA

Verify that the `publish_to` field has been removed from `pubspec.yaml` and that the `documentation` url has been updated to the url that'll be available once we publish to `pub.dartlang.org`.