### PR TITLE
Make distinction of Microsoft Edge vs Internet Explorer

### DIFF
--- a/lib/src/browser.dart
+++ b/lib/src/browser.dart
@@ -40,6 +40,10 @@ class Browser {
 
   Version _version;
 
+  void reset() {
+    _version = null;
+  }
+
   Version get version {
     if (_version == null) {
       if (_parseVersion != null) {
@@ -57,6 +61,7 @@ class Browser {
     _firefox,
     _safari,
     _internetExplorer,
+    _edge,
     _wkWebView
   ];
 
@@ -64,6 +69,7 @@ class Browser {
   bool get isFirefox => this == _firefox;
   bool get isSafari => this == _safari;
   bool get isInternetExplorer => this == _internetExplorer;
+  bool get isEdge => this == _edge;
   bool get isWKWebView => this == _wkWebView;
 }
 
@@ -71,6 +77,7 @@ Browser _chrome = new _Chrome();
 Browser _firefox = new _Firefox();
 Browser _safari = new _Safari();
 Browser _internetExplorer = new _InternetExplorer();
+Browser _edge = new _Edge();
 Browser _wkWebView = new _WKWebView();
 
 class _Chrome extends Browser {
@@ -156,13 +163,13 @@ class _InternetExplorer extends Browser {
 
   static bool _isInternetExplorer(NavigatorProvider navigator) {
     return navigator.appName.contains('Microsoft') ||
-        navigator.appVersion.contains('Trident') ||
-        navigator.appVersion.contains('Edge');
+        navigator.appVersion.contains('Trident');
   }
 
   static Version _getVersion(NavigatorProvider navigator) {
     Match match =
         new RegExp(r'MSIE (\d+)\.(\d+);').firstMatch(navigator.appVersion);
+
     if (match != null) {
       var major = int.parse(match.group(1));
       var minor = int.parse(match.group(2));
@@ -176,7 +183,20 @@ class _InternetExplorer extends Browser {
       return new Version(major, minor, 0);
     }
 
-    match = new RegExp(r'Edge/(\d+)\.(\d+)$').firstMatch(navigator.appVersion);
+    return new Version(0, 0, 0);
+  }
+}
+
+class _Edge extends Browser {
+  _Edge() : super('Edge', _isEdge, _getVersion);
+
+  static bool _isEdge(NavigatorProvider navigator) {
+    return navigator.appVersion.contains('Edge');
+  }
+
+  static Version _getVersion(NavigatorProvider navigator) {
+    Match match =
+        new RegExp(r'Edge/(\d+)\.(\d+)$').firstMatch(navigator.appVersion);
     if (match != null) {
       var major = int.parse(match.group(1));
       var minor = int.parse(match.group(2));

--- a/test/browser_test.dart
+++ b/test/browser_test.dart
@@ -13,12 +13,15 @@ void main() {
     test('Unknown Browser', () {
       Browser.navigator = new TestNavigator();
       var browser = Browser.getCurrentBrowser();
+      browser.reset();
+
       expect(browser.name, Browser.UnknownBrowser.name);
       expect(browser.version, Browser.UnknownBrowser.version);
       expect(browser.isChrome, false);
       expect(browser.isFirefox, false);
       expect(browser.isSafari, false);
       expect(browser.isInternetExplorer, false);
+      expect(browser.isEdge, false);
     });
 
     test('Fake Browser', () {
@@ -30,6 +33,7 @@ void main() {
       expect(browser.isFirefox, false);
       expect(browser.isSafari, false);
       expect(browser.isInternetExplorer, false);
+      expect(browser.isEdge, false);
     });
 
     test('Chrome', () {
@@ -39,29 +43,87 @@ void main() {
           ..vendor = 'Google Inc.';
       Browser.navigator = navigator;
       Browser browser = Browser.getCurrentBrowser();
+      browser.reset();
 
       expect(browser.name, 'Chrome');
       expect(browser.isChrome, true);
       expect(browser.isFirefox, false);
       expect(browser.isSafari, false);
       expect(browser.isInternetExplorer, false);
+      expect(browser.isEdge, false);
       expect(browser.version, new Version(53, 0, 2785, build: '143'));
     });
 
-    test('Internet Explorer', () {
+    test('Internet Explorer 11', () {
       var navigator = new TestNavigator()
           ..userAgent = 'Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; .NET4.0C; .NET4.0E; rv:11.0) like Gecko'
           ..appVersion = '5.0 (Windows NT 6.1; WOW64; Trident/7.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; .NET4.0C; .NET4.0E; rv:11.0) like Gecko'
           ..appName = 'Netscape';
       Browser.navigator = navigator;
       Browser browser = Browser.getCurrentBrowser();
+      browser.reset();
 
       expect(browser.name, 'Internet Explorer');
       expect(browser.isChrome, false);
       expect(browser.isFirefox, false);
       expect(browser.isSafari, false);
       expect(browser.isInternetExplorer, true);
+      expect(browser.isEdge, false);
       expect(browser.version, new Version(11, 0, 0));
+    });
+
+    test('Internet Explorer 10', () {
+      var navigator = new TestNavigator()
+          ..userAgent = 'Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; Trident/6.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; .NET4.0C)'
+          ..appVersion = '5.0 (compatible; MSIE 10.0; Windows NT 6.1; Trident/6.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; .NET4.0C)'
+          ..appName = 'Microsoft Internet Explorer';
+      Browser.navigator = navigator;
+      Browser browser = Browser.getCurrentBrowser();
+      browser.reset();
+
+      expect(browser.name, 'Internet Explorer');
+      expect(browser.isChrome, false);
+      expect(browser.isFirefox, false);
+      expect(browser.isSafari, false);
+      expect(browser.isInternetExplorer, true);
+      expect(browser.isEdge, false);
+      expect(browser.version, new Version(10, 0, 0));
+    });
+
+    test('Internet Explorer 9', () {
+      var navigator = new TestNavigator()
+          ..userAgent = 'Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; .NET4.0C)'
+          ..appVersion = '5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; .NET4.0C)'
+          ..appName = 'Microsoft Internet Explorer';
+      Browser.navigator = navigator;
+      Browser browser = Browser.getCurrentBrowser();
+      browser.reset();
+
+      expect(browser.name, 'Internet Explorer');
+      expect(browser.isChrome, false);
+      expect(browser.isFirefox, false);
+      expect(browser.isSafari, false);
+      expect(browser.isInternetExplorer, true);
+      expect(browser.isEdge, false);
+      expect(browser.version, new Version(9, 0, 0));
+    });
+
+    test('Internet Explorer 8', () {
+      var navigator = new TestNavigator()
+          ..userAgent = 'Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.1; Trident/4.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; .NET4.0C)'
+          ..appVersion = '4.0 (compatible; MSIE 8.0; Windows NT 6.1; Trident/4.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; .NET4.0C)'
+          ..appName = 'Microsoft Internet Explorer';
+      Browser.navigator = navigator;
+      Browser browser = Browser.getCurrentBrowser();
+      browser.reset();
+
+      expect(browser.name, 'Internet Explorer');
+      expect(browser.isChrome, false);
+      expect(browser.isFirefox, false);
+      expect(browser.isSafari, false);
+      expect(browser.isInternetExplorer, true);
+      expect(browser.isEdge, false);
+      expect(browser.version, new Version(8, 0, 0));
     });
 
     test('Firefox', () {
@@ -71,12 +133,14 @@ void main() {
           ..appName = 'Netscape';
       Browser.navigator = navigator;
       Browser browser = Browser.getCurrentBrowser();
+      browser.reset();
 
       expect(browser.name, 'Firefox');
       expect(browser.isChrome, false);
       expect(browser.isFirefox, true);
       expect(browser.isSafari, false);
       expect(browser.isInternetExplorer, false);
+      expect(browser.isEdge, false);
       expect(browser.version, new Version(48, 0, 0));
     });
 
@@ -88,12 +152,14 @@ void main() {
           ..appName = 'Netscape';
       Browser.navigator = navigator;
       Browser browser = Browser.getCurrentBrowser();
+      browser.reset();
 
       expect(browser.name, 'Safari');
       expect(browser.isChrome, false);
       expect(browser.isFirefox, false);
       expect(browser.isSafari, true);
       expect(browser.isInternetExplorer, false);
+      expect(browser.isEdge, false);
       expect(browser.version, new Version(9, 1, 3));
     });
 
@@ -106,6 +172,7 @@ void main() {
 
       Browser.navigator = navigator;
       Browser browser = Browser.getCurrentBrowser();
+      browser.reset();
 
       expect(browser.name, 'WKWebView');
       expect(browser.isChrome, false);
@@ -113,7 +180,29 @@ void main() {
       expect(browser.isSafari, false);
       expect(browser.isWKWebView, true);
       expect(browser.isInternetExplorer, false);
+      expect(browser.isEdge, false);
       expect(browser.version, new Version(601, 7, 8));
+    });
+
+    test('Edge', () {
+      var navigator = new TestNavigator()
+          ..vendor = ''
+          ..userAgent = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.79 Safari/537.36 Edge/14.14393'
+          ..appVersion = '5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.79 Safari/537.36 Edge/14.14393'
+          ..appName = 'Netscape';
+
+      Browser.navigator = navigator;
+      Browser browser = Browser.getCurrentBrowser();
+      browser.reset();
+
+      expect(browser.name, 'Edge');
+      expect(browser.isChrome, false);
+      expect(browser.isFirefox, false);
+      expect(browser.isSafari, false);
+      expect(browser.isWKWebView, false);
+      expect(browser.isInternetExplorer, false);
+      expect(browser.isEdge, true);
+      expect(browser.version, new Version(14, 14393, 0));
     });
   });
 }


### PR DESCRIPTION
## What

In canary we need the distinction of Internet Explorer vs Microsoft Edge.

## Solution

Create an edge browser class which checks for the relevant properties on navigator objects.

## QA

Unit tests should pass and microsoft edge should be detectable when necessary.