### PR TITLE
RAP-1697 Add some simple test utilities for setting the navigators

### DIFF
--- a/example/main.dart
+++ b/example/main.dart
@@ -13,20 +13,24 @@ main() {
 void _parseCurrentBrowser() {
   document.querySelector('#current-browser').text = browser.name;
   document.querySelector('#current-vendor').text = window.navigator.vendor;
-  document.querySelector('#current-appVersion').text = window.navigator.appVersion;
+  document.querySelector('#current-appVersion').text =
+      window.navigator.appVersion;
   document.querySelector('#current-appName').text = window.navigator.appName;
-  document.querySelector('#current-userAgent').text = window.navigator.userAgent;
+  document.querySelector('#current-userAgent').text =
+      window.navigator.userAgent;
 
   CheckboxInputElement isChrome = document.querySelector('#current-is-chrome');
   isChrome.checked = browser.isChrome;
 
-  CheckboxInputElement isFirefox = document.querySelector('#current-is-firefox');
+  CheckboxInputElement isFirefox =
+      document.querySelector('#current-is-firefox');
   isFirefox.checked = browser.isFirefox;
 
   CheckboxInputElement isSafari = document.querySelector('#current-is-safari');
   isSafari.checked = browser.isSafari;
 
-  CheckboxInputElement isInternetExplorer = document.querySelector('#current-is-ie');
+  CheckboxInputElement isInternetExplorer =
+      document.querySelector('#current-is-ie');
   isInternetExplorer.checked = browser.isInternetExplorer;
 
   document.querySelector('#current-version').text = browser.version.toString();

--- a/lib/platform_detect.dart
+++ b/lib/platform_detect.dart
@@ -11,4 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+export 'package:platform_detect/src/browser.dart' show Browser;
 export 'package:platform_detect/src/detect.dart' show browser, operatingSystem;
+export 'package:platform_detect/src/operating_system.dart' show OperatingSystem;

--- a/lib/platform_detect.dart
+++ b/lib/platform_detect.dart
@@ -11,48 +11,4 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
-/// Enables detection of browser type and version and operating system
-///
-/// Use browser.isChrome or operatingSystem.isMac
-library platform_detect;
-
-import 'dart:html';
-
-import 'package:platform_detect/src/browser.dart';
-import 'package:platform_detect/src/navigator.dart';
-import 'package:platform_detect/src/operating_system.dart';
-
-export 'src/browser.dart';
-export 'src/operating_system.dart';
-
-Browser _browser;
-
-/// Current browser info
-Browser get browser {
-  if (_browser == null) {
-    Browser.navigator = new _HtmlNavigator();
-    _browser = Browser.getCurrentBrowser();
-  }
-
-  return _browser;
-}
-
-OperatingSystem _operatingSystem;
-
-/// Current operating system info
-OperatingSystem get operatingSystem {
-  if (_operatingSystem == null) {
-    OperatingSystem.navigator = new _HtmlNavigator();
-    _operatingSystem = OperatingSystem.getCurrentOperatingSystem();
-  }
-
-  return _operatingSystem;
-}
-
-class _HtmlNavigator implements NavigatorProvider {
-  String get vendor => window.navigator.vendor;
-  String get appVersion => window.navigator.appVersion;
-  String get appName => window.navigator.appName;
-  String get userAgent => window.navigator.userAgent;
-}
+export 'package:platform_detect/src/detect.dart' show browser, operatingSystem;

--- a/lib/platform_detect.dart
+++ b/lib/platform_detect.dart
@@ -13,4 +13,5 @@
 // limitations under the License.
 export 'package:platform_detect/src/browser.dart' show Browser;
 export 'package:platform_detect/src/detect.dart' show browser, operatingSystem;
+export 'package:platform_detect/src/navigator.dart' show TestNavigator;
 export 'package:platform_detect/src/operating_system.dart' show OperatingSystem;

--- a/lib/src/browser.dart
+++ b/lib/src/browser.dart
@@ -11,9 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
-library platform_detect.browser;
-
 import 'package:pub_semver/pub_semver.dart';
 import 'package:platform_detect/src/navigator.dart';
 
@@ -53,25 +50,25 @@ class Browser {
   }
 
   static List<Browser> _knownBrowsers = [
-    _chrome,
-    _firefox,
-    _safari,
-    _internetExplorer,
-    _wkWebView
+    chrome,
+    firefox,
+    safari,
+    internetExplorer,
+    wkWebView
   ];
 
-  bool get isChrome => this == _chrome;
-  bool get isFirefox => this == _firefox;
-  bool get isSafari => this == _safari;
-  bool get isInternetExplorer => this == _internetExplorer;
-  bool get isWKWebView => this == _wkWebView;
+  bool get isChrome => this == chrome;
+  bool get isFirefox => this == firefox;
+  bool get isSafari => this == safari;
+  bool get isInternetExplorer => this == internetExplorer;
+  bool get isWKWebView => this == wkWebView;
 }
 
-Browser _chrome = new _Chrome();
-Browser _firefox = new _Firefox();
-Browser _safari = new _Safari();
-Browser _internetExplorer = new _InternetExplorer();
-Browser _wkWebView = new _WKWebView();
+Browser chrome = new _Chrome();
+Browser firefox = new _Firefox();
+Browser safari = new _Safari();
+Browser internetExplorer = new _InternetExplorer();
+Browser wkWebView = new _WKWebView();
 
 class _Chrome extends Browser {
   _Chrome() : super('Chrome', _isChrome, _getVersion);

--- a/lib/src/detect.dart
+++ b/lib/src/detect.dart
@@ -23,7 +23,8 @@ import 'package:platform_detect/src/operating_system.dart';
 ///
 /// Calling this method with no arguments will reset the library to its
 /// default behavior.
-void configureForTesting({Browser browser, OperatingSystem operatingSystem}) {
+void configurePlatformForTesting(
+    {Browser browser, OperatingSystem operatingSystem}) {
   _browser = browser;
   _operatingSystem = operatingSystem;
 }

--- a/lib/src/detect.dart
+++ b/lib/src/detect.dart
@@ -1,0 +1,60 @@
+// Copyright 2017 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import 'dart:html';
+
+import 'package:platform_detect/src/browser.dart';
+import 'package:platform_detect/src/navigator.dart';
+import 'package:platform_detect/src/operating_system.dart';
+
+/// A test utility that allows a consumer to instruct the library to
+/// respond as though it was running on a particular browser and / or
+/// operating system.
+///
+/// Calling this method with no arguments will reset the library to its
+/// default behavior.
+void configureForTesting({Browser browser, OperatingSystem operatingSystem}) {
+  _browser = browser;
+  _operatingSystem = operatingSystem;
+}
+
+Browser _browser;
+
+/// Current browser info
+Browser get browser {
+  if (_browser == null) {
+    Browser.navigator = new _HtmlNavigator();
+    _browser = Browser.getCurrentBrowser();
+  }
+
+  return _browser;
+}
+
+OperatingSystem _operatingSystem;
+
+/// Current operating system info
+OperatingSystem get operatingSystem {
+  if (_operatingSystem == null) {
+    OperatingSystem.navigator = new _HtmlNavigator();
+    _operatingSystem = OperatingSystem.getCurrentOperatingSystem();
+  }
+
+  return _operatingSystem;
+}
+
+class _HtmlNavigator implements NavigatorProvider {
+  String get vendor => window.navigator.vendor;
+  String get appVersion => window.navigator.appVersion;
+  String get appName => window.navigator.appName;
+  String get userAgent => window.navigator.userAgent;
+}

--- a/lib/src/operating_system.dart
+++ b/lib/src/operating_system.dart
@@ -34,30 +34,30 @@ class OperatingSystem {
   OperatingSystem(this.name, bool matchesNavigator(NavigatorProvider navigator))
       : this._matchesNavigator = matchesNavigator;
 
-  static List<OperatingSystem> _knownSystems = [_mac, _windows, _unix, _linux];
+  static List<OperatingSystem> _knownSystems = [_mac, _windows, _linux, _unix];
 
-  get isMac => this == _mac;
-  get isWindows => this == _windows;
-  get isUnix => this == _unix;
   get isLinux => this == _linux;
+  get isMac => this == _mac;
+  get isUnix => this == _unix;
+  get isWindows => this == _windows;
+
+  static OperatingSystem _linux =
+  new OperatingSystem('Linux', (NavigatorProvider navigator) {
+    return navigator.appVersion.contains('Linux');
+  });
 
   static OperatingSystem _mac =
       new OperatingSystem('Mac', (NavigatorProvider navigator) {
     return navigator.appVersion.contains('Mac');
   });
 
-  static OperatingSystem _windows =
-      new OperatingSystem('Windows', (NavigatorProvider navigator) {
-    return navigator.appVersion.contains('Win');
-  });
-
   static OperatingSystem _unix =
-      new OperatingSystem('Unix', (NavigatorProvider navigator) {
+  new OperatingSystem('Unix', (NavigatorProvider navigator) {
     return navigator.appVersion.contains('X11');
   });
 
-  static OperatingSystem _linux =
-      new OperatingSystem('Linux', (NavigatorProvider navigator) {
-    return navigator.appVersion.contains('Linux');
+  static OperatingSystem _windows =
+      new OperatingSystem('Windows', (NavigatorProvider navigator) {
+    return navigator.appVersion.contains('Win');
   });
 }

--- a/lib/src/operating_system.dart
+++ b/lib/src/operating_system.dart
@@ -40,21 +40,20 @@ class OperatingSystem {
 }
 
 OperatingSystem linux =
-new OperatingSystem('Linux', (NavigatorProvider navigator) {
+    new OperatingSystem('Linux', (NavigatorProvider navigator) {
   return navigator.appVersion.contains('Linux');
 });
 
-OperatingSystem mac =
-new OperatingSystem('Mac', (NavigatorProvider navigator) {
+OperatingSystem mac = new OperatingSystem('Mac', (NavigatorProvider navigator) {
   return navigator.appVersion.contains('Mac');
 });
 
 OperatingSystem unix =
-new OperatingSystem('Unix', (NavigatorProvider navigator) {
+    new OperatingSystem('Unix', (NavigatorProvider navigator) {
   return navigator.appVersion.contains('X11');
 });
 
 OperatingSystem windows =
-new OperatingSystem('Windows', (NavigatorProvider navigator) {
+    new OperatingSystem('Windows', (NavigatorProvider navigator) {
   return navigator.appVersion.contains('Win');
 });

--- a/lib/src/operating_system.dart
+++ b/lib/src/operating_system.dart
@@ -11,9 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
-library platform_detect.operating_system;
-
 import 'package:platform_detect/src/navigator.dart';
 
 /// Matches an operating system name with how it is represented in window.navigator
@@ -34,30 +31,30 @@ class OperatingSystem {
   OperatingSystem(this.name, bool matchesNavigator(NavigatorProvider navigator))
       : this._matchesNavigator = matchesNavigator;
 
-  static List<OperatingSystem> _knownSystems = [_mac, _windows, _linux, _unix];
+  static List<OperatingSystem> _knownSystems = [mac, windows, linux, unix];
 
-  get isLinux => this == _linux;
-  get isMac => this == _mac;
-  get isUnix => this == _unix;
-  get isWindows => this == _windows;
-
-  static OperatingSystem _linux =
-  new OperatingSystem('Linux', (NavigatorProvider navigator) {
-    return navigator.appVersion.contains('Linux');
-  });
-
-  static OperatingSystem _mac =
-      new OperatingSystem('Mac', (NavigatorProvider navigator) {
-    return navigator.appVersion.contains('Mac');
-  });
-
-  static OperatingSystem _unix =
-  new OperatingSystem('Unix', (NavigatorProvider navigator) {
-    return navigator.appVersion.contains('X11');
-  });
-
-  static OperatingSystem _windows =
-      new OperatingSystem('Windows', (NavigatorProvider navigator) {
-    return navigator.appVersion.contains('Win');
-  });
+  get isLinux => this == linux;
+  get isMac => this == mac;
+  get isUnix => this == unix;
+  get isWindows => this == windows;
 }
+
+OperatingSystem linux =
+new OperatingSystem('Linux', (NavigatorProvider navigator) {
+  return navigator.appVersion.contains('Linux');
+});
+
+OperatingSystem mac =
+new OperatingSystem('Mac', (NavigatorProvider navigator) {
+  return navigator.appVersion.contains('Mac');
+});
+
+OperatingSystem unix =
+new OperatingSystem('Unix', (NavigatorProvider navigator) {
+  return navigator.appVersion.contains('X11');
+});
+
+OperatingSystem windows =
+new OperatingSystem('Windows', (NavigatorProvider navigator) {
+  return navigator.appVersion.contains('Win');
+});

--- a/lib/test_utils.dart
+++ b/lib/test_utils.dart
@@ -1,47 +1,16 @@
-import 'package:platform_detect/src/browser.dart';
-import 'package:platform_detect/src/navigator.dart';
-import 'package:platform_detect/src/operating_system.dart';
-
-class BrowserNavigators {
-  static final NavigatorProvider chrome = new TestNavigator()
-    ..userAgent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.143 Safari/537.36'
-    ..appVersion = '5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.143 Safari/537.36'
-    ..vendor = 'Google Inc.';
-  static final NavigatorProvider firefox = new TestNavigator()
-    ..userAgent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:48.0) Gecko/20100101 Firefox/48.0'
-    ..appVersion = '5.0 (Macintosh)'
-    ..appName = 'Netscape';
-  static final NavigatorProvider internetExplorer = new TestNavigator()
-    ..userAgent = 'Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; .NET4.0C; .NET4.0E; rv:11.0) like Gecko'
-    ..appVersion = '5.0 (Windows NT 6.1; WOW64; Trident/7.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; .NET4.0C; .NET4.0E; rv:11.0) like Gecko'
-    ..appName = 'Netscape';
-  static final NavigatorProvider safari = new TestNavigator()
-    ..vendor = 'Apple Computer, Inc.'
-    ..userAgent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/601.7.8 (KHTML, like Gecko) Version/9.1.3 Safari/601.7.8'
-    ..appVersion = '5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/601.7.8 (KHTML, like Gecko) Version/9.1.3 Safari/601.7.8'
-    ..appName = 'Netscape';
-  static final NavigatorProvider wkWebView = new TestNavigator()
-    ..vendor = 'Apple Computer, Inc.'
-    ..userAgent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/601.7.8 (KHTML, like Gecko) Version/9.1.3 Safari/601.7.8'
-    ..appVersion = '5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/601.7.8 (KHTML, like Gecko) Safari/601.7.8'
-    ..appName = 'Netscape';
-
-  /// Set the [NavigatorProvider] that will be used to determine the
-  /// current browser.
-  static void set(NavigatorProvider provider) {
-    Browser.navigator = provider;
-  }
-}
-
-class OperatingSystemNavigators {
-  static final NavigatorProvider linux = new TestNavigator()..appVersion = 'Linux';
-  static final NavigatorProvider mac = new TestNavigator()..appVersion = 'Macintosh';
-  static final NavigatorProvider unix = new TestNavigator()..appVersion = 'X11';
-  static final NavigatorProvider windows = new TestNavigator()..appVersion = 'Windows';
-
-  /// Set the [NavigatorProvider] that will be used to determine the
-  /// current operating system.
-  static void set(NavigatorProvider provider) {
-    OperatingSystem.navigator = provider;
-  }
-}
+// Copyright 2017 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+export 'package:platform_detect/src/detect.dart' show configureForTesting;
+export 'package:platform_detect/src/browser.dart' show chrome, firefox, internetExplorer, safari, wkWebView;
+export 'package:platform_detect/src/operating_system.dart' show linux, mac, unix, windows;

--- a/lib/test_utils.dart
+++ b/lib/test_utils.dart
@@ -12,5 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 export 'package:platform_detect/src/detect.dart' show configureForTesting;
-export 'package:platform_detect/src/browser.dart' show chrome, firefox, internetExplorer, safari, wkWebView;
-export 'package:platform_detect/src/operating_system.dart' show linux, mac, unix, windows;
+export 'package:platform_detect/src/browser.dart'
+    show chrome, firefox, internetExplorer, safari, wkWebView;
+export 'package:platform_detect/src/operating_system.dart'
+    show linux, mac, unix, windows;

--- a/lib/test_utils.dart
+++ b/lib/test_utils.dart
@@ -1,0 +1,47 @@
+import 'package:platform_detect/src/browser.dart';
+import 'package:platform_detect/src/navigator.dart';
+import 'package:platform_detect/src/operating_system.dart';
+
+class BrowserNavigators {
+  static final NavigatorProvider chrome = new TestNavigator()
+    ..userAgent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.143 Safari/537.36'
+    ..appVersion = '5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.143 Safari/537.36'
+    ..vendor = 'Google Inc.';
+  static final NavigatorProvider firefox = new TestNavigator()
+    ..userAgent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:48.0) Gecko/20100101 Firefox/48.0'
+    ..appVersion = '5.0 (Macintosh)'
+    ..appName = 'Netscape';
+  static final NavigatorProvider internetExplorer = new TestNavigator()
+    ..userAgent = 'Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; .NET4.0C; .NET4.0E; rv:11.0) like Gecko'
+    ..appVersion = '5.0 (Windows NT 6.1; WOW64; Trident/7.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; .NET4.0C; .NET4.0E; rv:11.0) like Gecko'
+    ..appName = 'Netscape';
+  static final NavigatorProvider safari = new TestNavigator()
+    ..vendor = 'Apple Computer, Inc.'
+    ..userAgent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/601.7.8 (KHTML, like Gecko) Version/9.1.3 Safari/601.7.8'
+    ..appVersion = '5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/601.7.8 (KHTML, like Gecko) Version/9.1.3 Safari/601.7.8'
+    ..appName = 'Netscape';
+  static final NavigatorProvider wkWebView = new TestNavigator()
+    ..vendor = 'Apple Computer, Inc.'
+    ..userAgent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/601.7.8 (KHTML, like Gecko) Version/9.1.3 Safari/601.7.8'
+    ..appVersion = '5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/601.7.8 (KHTML, like Gecko) Safari/601.7.8'
+    ..appName = 'Netscape';
+
+  /// Set the [NavigatorProvider] that will be used to determine the
+  /// current browser.
+  static void set(NavigatorProvider provider) {
+    Browser.navigator = provider;
+  }
+}
+
+class OperatingSystemNavigators {
+  static final NavigatorProvider linux = new TestNavigator()..appVersion = 'Linux';
+  static final NavigatorProvider mac = new TestNavigator()..appVersion = 'Macintosh';
+  static final NavigatorProvider unix = new TestNavigator()..appVersion = 'X11';
+  static final NavigatorProvider windows = new TestNavigator()..appVersion = 'Windows';
+
+  /// Set the [NavigatorProvider] that will be used to determine the
+  /// current operating system.
+  static void set(NavigatorProvider provider) {
+    OperatingSystem.navigator = provider;
+  }
+}

--- a/lib/test_utils.dart
+++ b/lib/test_utils.dart
@@ -11,7 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-export 'package:platform_detect/src/detect.dart' show configureForTesting;
+export 'package:platform_detect/src/detect.dart'
+    show configurePlatformForTesting;
 export 'package:platform_detect/src/browser.dart'
     show chrome, firefox, internetExplorer, safari, wkWebView;
 export 'package:platform_detect/src/operating_system.dart'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,15 +6,15 @@ homepage: https://github.com/Workiva/platform_detect
 documentation: https://www.dartdocs.org/documentation/platform_detect/latest
 
 environment:
-  sdk: ">=1.12.1 <2.0.0"
+  sdk: ">=1.13.0 <2.0.0"
 
 dependencies:
   pub_semver: ^1.0.0
 
 dev_dependencies:
-  dartdoc: ^0.9.7
-  dart_style: 0.2.10
+  dartdoc: '>=0.8.0 <=0.10.0'
+  dart_style: '>=0.1.8 <0.3.0'
   coverage: ^0.7.9
   browser: any
-  dart_dev: ^1.4.2
+  dart_dev: ^1.7.2
   test: ^0.12.0

--- a/test/browser_test.dart
+++ b/test/browser_test.dart
@@ -6,26 +6,35 @@ import 'package:platform_detect/src/browser.dart';
 import 'package:platform_detect/src/navigator.dart';
 
 final chrome = new TestNavigator()
-  ..userAgent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.143 Safari/537.36'
-  ..appVersion = '5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.143 Safari/537.36'
+  ..userAgent =
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.143 Safari/537.36'
+  ..appVersion =
+      '5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.143 Safari/537.36'
   ..vendor = 'Google Inc.';
 final firefox = new TestNavigator()
-  ..userAgent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:48.0) Gecko/20100101 Firefox/48.0'
+  ..userAgent =
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:48.0) Gecko/20100101 Firefox/48.0'
   ..appVersion = '5.0 (Macintosh)'
   ..appName = 'Netscape';
 final internetExplorer = new TestNavigator()
-  ..userAgent = 'Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; .NET4.0C; .NET4.0E; rv:11.0) like Gecko'
-  ..appVersion = '5.0 (Windows NT 6.1; WOW64; Trident/7.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; .NET4.0C; .NET4.0E; rv:11.0) like Gecko'
+  ..userAgent =
+      'Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; .NET4.0C; .NET4.0E; rv:11.0) like Gecko'
+  ..appVersion =
+      '5.0 (Windows NT 6.1; WOW64; Trident/7.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; .NET4.0C; .NET4.0E; rv:11.0) like Gecko'
   ..appName = 'Netscape';
 final safari = new TestNavigator()
   ..vendor = 'Apple Computer, Inc.'
-  ..userAgent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/601.7.8 (KHTML, like Gecko) Version/9.1.3 Safari/601.7.8'
-  ..appVersion = '5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/601.7.8 (KHTML, like Gecko) Version/9.1.3 Safari/601.7.8'
+  ..userAgent =
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/601.7.8 (KHTML, like Gecko) Version/9.1.3 Safari/601.7.8'
+  ..appVersion =
+      '5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/601.7.8 (KHTML, like Gecko) Version/9.1.3 Safari/601.7.8'
   ..appName = 'Netscape';
 final wkWebView = new TestNavigator()
   ..vendor = 'Apple Computer, Inc.'
-  ..userAgent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/601.7.8 (KHTML, like Gecko) Version/9.1.3 Safari/601.7.8'
-  ..appVersion = '5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/601.7.8 (KHTML, like Gecko) Safari/601.7.8'
+  ..userAgent =
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/601.7.8 (KHTML, like Gecko) Version/9.1.3 Safari/601.7.8'
+  ..appVersion =
+      '5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/601.7.8 (KHTML, like Gecko) Safari/601.7.8'
   ..appName = 'Netscape';
 
 void main() {
@@ -46,8 +55,8 @@ void main() {
     });
 
     test('Fake Browser', () {
-      Browser browser = new Browser(
-          'Fake', (_) => true, (_) => new Version(1, 1, 0));
+      Browser browser =
+          new Browser('Fake', (_) => true, (_) => new Version(1, 1, 0));
       expect(browser.name, 'Fake');
       expect(browser.version, new Version(1, 1, 0));
       expect(browser.isChrome, false);

--- a/test/browser_test.dart
+++ b/test/browser_test.dart
@@ -1,9 +1,32 @@
 @TestOn('vm')
-import 'package:platform_detect/src/browser.dart';
-import 'package:platform_detect/src/navigator.dart';
-import 'package:platform_detect/test_utils.dart';
 import 'package:pub_semver/pub_semver.dart';
 import 'package:test/test.dart';
+
+import 'package:platform_detect/src/browser.dart';
+import 'package:platform_detect/src/navigator.dart';
+
+final chrome = new TestNavigator()
+  ..userAgent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.143 Safari/537.36'
+  ..appVersion = '5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.143 Safari/537.36'
+  ..vendor = 'Google Inc.';
+final firefox = new TestNavigator()
+  ..userAgent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:48.0) Gecko/20100101 Firefox/48.0'
+  ..appVersion = '5.0 (Macintosh)'
+  ..appName = 'Netscape';
+final internetExplorer = new TestNavigator()
+  ..userAgent = 'Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; .NET4.0C; .NET4.0E; rv:11.0) like Gecko'
+  ..appVersion = '5.0 (Windows NT 6.1; WOW64; Trident/7.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; .NET4.0C; .NET4.0E; rv:11.0) like Gecko'
+  ..appName = 'Netscape';
+final safari = new TestNavigator()
+  ..vendor = 'Apple Computer, Inc.'
+  ..userAgent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/601.7.8 (KHTML, like Gecko) Version/9.1.3 Safari/601.7.8'
+  ..appVersion = '5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/601.7.8 (KHTML, like Gecko) Version/9.1.3 Safari/601.7.8'
+  ..appName = 'Netscape';
+final wkWebView = new TestNavigator()
+  ..vendor = 'Apple Computer, Inc.'
+  ..userAgent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/601.7.8 (KHTML, like Gecko) Version/9.1.3 Safari/601.7.8'
+  ..appVersion = '5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/601.7.8 (KHTML, like Gecko) Safari/601.7.8'
+  ..appName = 'Netscape';
 
 void main() {
   group('browser detects', () {
@@ -34,7 +57,7 @@ void main() {
     });
 
     test('Chrome', () {
-      Browser.navigator = BrowserNavigators.chrome;
+      Browser.navigator = chrome;
       Browser browser = Browser.getCurrentBrowser();
 
       expect(browser.name, 'Chrome');
@@ -46,7 +69,7 @@ void main() {
     });
 
     test('Internet Explorer', () {
-      Browser.navigator = BrowserNavigators.internetExplorer;
+      Browser.navigator = internetExplorer;
       Browser browser = Browser.getCurrentBrowser();
 
       expect(browser.name, 'Internet Explorer');
@@ -58,7 +81,7 @@ void main() {
     });
 
     test('Firefox', () {
-      Browser.navigator = BrowserNavigators.firefox;
+      Browser.navigator = firefox;
       Browser browser = Browser.getCurrentBrowser();
 
       expect(browser.name, 'Firefox');
@@ -70,7 +93,7 @@ void main() {
     });
 
     test('Safari', () {
-      Browser.navigator = BrowserNavigators.safari;
+      Browser.navigator = safari;
       Browser browser = Browser.getCurrentBrowser();
 
       expect(browser.name, 'Safari');
@@ -82,7 +105,7 @@ void main() {
     });
 
     test('WKWebView', () {
-      Browser.navigator = BrowserNavigators.wkWebView;
+      Browser.navigator = wkWebView;
       Browser browser = Browser.getCurrentBrowser();
 
       expect(browser.name, 'WKWebView');

--- a/test/browser_test.dart
+++ b/test/browser_test.dart
@@ -1,6 +1,7 @@
 @TestOn('vm')
 import 'package:platform_detect/src/browser.dart';
 import 'package:platform_detect/src/navigator.dart';
+import 'package:platform_detect/test_utils.dart';
 import 'package:pub_semver/pub_semver.dart';
 import 'package:test/test.dart';
 
@@ -33,11 +34,7 @@ void main() {
     });
 
     test('Chrome', () {
-      var navigator = new TestNavigator()
-          ..userAgent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.143 Safari/537.36'
-          ..appVersion = '5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.143 Safari/537.36'
-          ..vendor = 'Google Inc.';
-      Browser.navigator = navigator;
+      Browser.navigator = BrowserNavigators.chrome;
       Browser browser = Browser.getCurrentBrowser();
 
       expect(browser.name, 'Chrome');
@@ -49,11 +46,7 @@ void main() {
     });
 
     test('Internet Explorer', () {
-      var navigator = new TestNavigator()
-          ..userAgent = 'Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; .NET4.0C; .NET4.0E; rv:11.0) like Gecko'
-          ..appVersion = '5.0 (Windows NT 6.1; WOW64; Trident/7.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; .NET4.0C; .NET4.0E; rv:11.0) like Gecko'
-          ..appName = 'Netscape';
-      Browser.navigator = navigator;
+      Browser.navigator = BrowserNavigators.internetExplorer;
       Browser browser = Browser.getCurrentBrowser();
 
       expect(browser.name, 'Internet Explorer');
@@ -65,11 +58,7 @@ void main() {
     });
 
     test('Firefox', () {
-      var navigator = new TestNavigator()
-          ..userAgent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:48.0) Gecko/20100101 Firefox/48.0'
-          ..appVersion = '5.0 (Macintosh)'
-          ..appName = 'Netscape';
-      Browser.navigator = navigator;
+      Browser.navigator = BrowserNavigators.firefox;
       Browser browser = Browser.getCurrentBrowser();
 
       expect(browser.name, 'Firefox');
@@ -81,12 +70,7 @@ void main() {
     });
 
     test('Safari', () {
-      var navigator = new TestNavigator()
-          ..vendor = 'Apple Computer, Inc.'
-          ..userAgent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/601.7.8 (KHTML, like Gecko) Version/9.1.3 Safari/601.7.8'
-          ..appVersion = '5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/601.7.8 (KHTML, like Gecko) Version/9.1.3 Safari/601.7.8'
-          ..appName = 'Netscape';
-      Browser.navigator = navigator;
+      Browser.navigator = BrowserNavigators.safari;
       Browser browser = Browser.getCurrentBrowser();
 
       expect(browser.name, 'Safari');
@@ -98,13 +82,7 @@ void main() {
     });
 
     test('WKWebView', () {
-      var navigator = new TestNavigator()
-          ..vendor = 'Apple Computer, Inc.'
-          ..userAgent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/601.7.8 (KHTML, like Gecko) Version/9.1.3 Safari/601.7.8'
-          ..appVersion = '5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/601.7.8 (KHTML, like Gecko) Safari/601.7.8'
-          ..appName = 'Netscape';
-
-      Browser.navigator = navigator;
+      Browser.navigator = BrowserNavigators.wkWebView;
       Browser browser = Browser.getCurrentBrowser();
 
       expect(browser.name, 'WKWebView');

--- a/test/operating_system_test.dart
+++ b/test/operating_system_test.dart
@@ -1,6 +1,7 @@
 @TestOn('vm')
 import 'package:platform_detect/src/operating_system.dart';
 import 'package:platform_detect/src/navigator.dart';
+import 'package:platform_detect/test_utils.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -20,7 +21,7 @@ void main() {
     });
 
     test('Windows Operating System', () {
-      OperatingSystem.navigator = new TestNavigator()..appVersion = 'Windows';
+      OperatingSystem.navigator = OperatingSystemNavigators.windows;
       var os = OperatingSystem.getCurrentOperatingSystem();
       expect(os.name, 'Windows');
       expect(os.isMac, false);
@@ -30,7 +31,7 @@ void main() {
     });
 
     test('Mac Operating System', () {
-      OperatingSystem.navigator = new TestNavigator()..appVersion = 'Macintosh';
+      OperatingSystem.navigator = OperatingSystemNavigators.mac;
       var os = OperatingSystem.getCurrentOperatingSystem();
       expect(os.name, 'Mac');
       expect(os.isMac, true);
@@ -40,7 +41,7 @@ void main() {
     });
 
     test('Unix Operating System', () {
-      OperatingSystem.navigator = new TestNavigator()..appVersion = 'X11';
+      OperatingSystem.navigator = OperatingSystemNavigators.unix;
       var os = OperatingSystem.getCurrentOperatingSystem();
       expect(os.name, 'Unix');
       expect(os.isMac, false);
@@ -50,7 +51,7 @@ void main() {
     });
 
     test('Linux Operating System', () {
-      OperatingSystem.navigator = new TestNavigator()..appVersion = 'Linux';
+      OperatingSystem.navigator = OperatingSystemNavigators.linux;
       var os = OperatingSystem.getCurrentOperatingSystem();
       expect(os.name, 'Linux');
       expect(os.isMac, false);

--- a/test/operating_system_test.dart
+++ b/test/operating_system_test.dart
@@ -1,8 +1,13 @@
 @TestOn('vm')
-import 'package:platform_detect/src/operating_system.dart';
-import 'package:platform_detect/src/navigator.dart';
-import 'package:platform_detect/test_utils.dart';
 import 'package:test/test.dart';
+
+import 'package:platform_detect/src/navigator.dart';
+import 'package:platform_detect/src/operating_system.dart';
+
+final linux = new TestNavigator()..appVersion = 'Linux';
+final mac = new TestNavigator()..appVersion = 'Macintosh';
+final unix = new TestNavigator()..appVersion = 'X11';
+final windows = new TestNavigator()..appVersion = 'Windows';
 
 void main() {
   group('operating system detects', () {
@@ -21,7 +26,7 @@ void main() {
     });
 
     test('Windows Operating System', () {
-      OperatingSystem.navigator = OperatingSystemNavigators.windows;
+      OperatingSystem.navigator = windows;
       var os = OperatingSystem.getCurrentOperatingSystem();
       expect(os.name, 'Windows');
       expect(os.isMac, false);
@@ -31,7 +36,7 @@ void main() {
     });
 
     test('Mac Operating System', () {
-      OperatingSystem.navigator = OperatingSystemNavigators.mac;
+      OperatingSystem.navigator = mac;
       var os = OperatingSystem.getCurrentOperatingSystem();
       expect(os.name, 'Mac');
       expect(os.isMac, true);
@@ -41,7 +46,7 @@ void main() {
     });
 
     test('Unix Operating System', () {
-      OperatingSystem.navigator = OperatingSystemNavigators.unix;
+      OperatingSystem.navigator = unix;
       var os = OperatingSystem.getCurrentOperatingSystem();
       expect(os.name, 'Unix');
       expect(os.isMac, false);
@@ -51,7 +56,7 @@ void main() {
     });
 
     test('Linux Operating System', () {
-      OperatingSystem.navigator = OperatingSystemNavigators.linux;
+      OperatingSystem.navigator = linux;
       var os = OperatingSystem.getCurrentOperatingSystem();
       expect(os.name, 'Linux');
       expect(os.isMac, false);

--- a/test/test_utils_test.dart
+++ b/test/test_utils_test.dart
@@ -1,0 +1,54 @@
+@TestOn('browser')
+import 'package:test/test.dart';
+
+import 'package:platform_detect/platform_detect.dart';
+import 'package:platform_detect/test_utils.dart';
+
+void main() {
+  group('platform detect test utils', () {
+    test('should set chrome', () {
+      configurePlatformForTesting(browser: chrome);
+      expect(browser.isChrome, isTrue);
+    });
+
+    test('should set firefox', () {
+      configurePlatformForTesting(browser: firefox);
+      expect(browser.isFirefox, isTrue);
+    });
+
+    test('should set internet explorer', () {
+      configurePlatformForTesting(browser: internetExplorer);
+      expect(browser.isInternetExplorer, isTrue);
+    });
+
+    test('should set safari', () {
+      configurePlatformForTesting(browser: safari);
+      expect(browser.isSafari, isTrue);
+    });
+
+    test('should set wkwebview', () {
+      configurePlatformForTesting(browser: wkWebView);
+      expect(browser.isWKWebView, isTrue);
+    });
+
+    test('should set linux', () {
+      configurePlatformForTesting(operatingSystem: linux);
+      expect(operatingSystem.isLinux, isTrue);
+    });
+
+    test('should set mac', () {
+      configurePlatformForTesting(operatingSystem: mac);
+      expect(operatingSystem.isMac, isTrue);
+    });
+
+    test('should set unix', () {
+      configurePlatformForTesting(operatingSystem: unix);
+      expect(operatingSystem.isUnix, isTrue);
+    });
+
+    test('should set windows', () {
+      configurePlatformForTesting(operatingSystem: windows);
+      expect(operatingSystem.isWindows, isTrue);
+    });
+  });
+}

--- a/tool/dev.dart
+++ b/tool/dev.dart
@@ -1,0 +1,25 @@
+import 'package:dart_dev/dart_dev.dart' show dev, config;
+
+main(List<String> args) async {
+  config.analyze.entryPoints = [
+    'example/main.dart',
+    'lib/platform_detect.dart',
+    'lib/test_utils.dart',
+    'test/browser_test.dart',
+    'test/operating_system_test.dart',
+    'test/test_utils_test.dart',
+    'tool/dev.dart',
+  ];
+
+  config.format
+    ..directories = [
+      'example/',
+      'lib/',
+      'test/',
+      'tool/',
+    ];
+
+  config.test..platforms = ['content-shell', 'vm'];
+
+  await dev(args);
+}


### PR DESCRIPTION
## Problem

Right now it takes a reasonable amount of internal knowledge about the library to mock it for testing. This is because doing so requires a `NavigatorProvider` to be created that will match the correct browser or OS.

## Solution

Move the existing test providers into the library and export them for use by other applications.

This will allow a consumer to fake a browser or OS like so...

```dart
import 'package:platform_detect/test_utils.dart';

// Pretend to be running on Chrome / Windows
configurePlatformForTesting(browser: chrome, operatingSystem: windows);

// Restore original behavior
configurePlatformForTesting();
```

Note: I'm not heavily invested in this particular solution, if someone has a better idea that'd be great. This was just the simplest way to get to where I wanted to be.

## Potential Regressions

None.

## Tests

Added and/or updated.

## QA / +10

1. Checkout the branch.
2. Update dependencies.
3. Unit tests should pass.

## FYI

@travissanderson-wf 
@clairesarsam-wf 
@Workiva/rich-app-platform-pp 