### PR TITLE
WP-3994 Update version parsing to handle Safari's practice of omitting patch

### DIFF
--- a/example/main.dart
+++ b/example/main.dart
@@ -83,6 +83,8 @@ void _parseTestValues() {
   Browser.navigator = navigator;
   OperatingSystem.navigator = navigator;
 
+  var browser = Browser.getCurrentBrowser();
+  var operatingSystem = OperatingSystem.getCurrentOperatingSystem();
   querySelector('#$testBrowserId-name').text = browser.name;
   querySelector('#$testBrowserId-version').text = browser.version.toString();
   querySelector('#$testOsId-name').text = operatingSystem.name;

--- a/lib/src/browser.dart
+++ b/lib/src/browser.dart
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+import 'package:meta/meta.dart';
 import 'package:pub_semver/pub_semver.dart';
 import 'package:platform_detect/src/navigator.dart';
 
@@ -23,6 +24,9 @@ class Browser {
         (browser) => browser._matchesNavigator(navigator),
         orElse: () => UnknownBrowser);
   }
+
+  @visibleForTesting
+  clearVersion() => _version = null;
 
   static Browser UnknownBrowser = new Browser('Unknown', null, null);
 
@@ -121,11 +125,12 @@ class _Safari extends Browser {
   }
 
   static Version _getVersion(NavigatorProvider navigator) {
-    Match match = new RegExp(r'Version/(\d+)\.(\d+)\.(\d+)')
+    Match match = new RegExp(r'Version/(\d+)(\.(\d+))?(\.(\d+))?')
         .firstMatch(navigator.appVersion);
     var major = int.parse(match.group(1));
-    var minor = int.parse(match.group(2));
-    var patch = int.parse(match.group(3));
+    var minor = int.parse(match.group(3) ?? '0');
+    var patch = int.parse(match.group(5) ?? '0');
+
     return new Version(major, minor, patch);
   }
 }

--- a/test/browser_test.dart
+++ b/test/browser_test.dart
@@ -70,16 +70,53 @@ void main() {
       expect(browser.version, new Version(48, 0, 0));
     });
 
-    test('Safari', () {
-      Browser.navigator = testSafari();
-      Browser browser = Browser.getCurrentBrowser();
+    group('Safari', () {
+      tearDown(() {
+        Browser.navigator = null;
+      });
 
-      expect(browser.name, 'Safari');
-      expect(browser.isChrome, false);
-      expect(browser.isFirefox, false);
-      expect(browser.isSafari, true);
-      expect(browser.isInternetExplorer, false);
-      expect(browser.version, new Version(9, 1, 3));
+      test('major, minor and patch version', () {
+        Browser.navigator = testSafari();
+        Browser browser = Browser.getCurrentBrowser();
+
+        expect(browser.name, 'Safari');
+        expect(browser.isChrome, false);
+        expect(browser.isFirefox, false);
+        expect(browser.isSafari, true);
+        expect(browser.isInternetExplorer, false);
+        expect(browser.version, new Version(9, 1, 3));
+      });
+
+      test('major and minor version', () {
+        Browser.navigator = testSafari(
+            userAgent: safariUserAgentWithoutPatchTestString,
+            appVersion: safariAppVersionWithoutPatchTestString);
+        print(Browser.navigator.userAgent);
+        Browser browser = Browser.getCurrentBrowser();
+        browser.clearVersion();
+
+        expect(browser.name, 'Safari');
+        expect(browser.isChrome, false);
+        expect(browser.isFirefox, false);
+        expect(browser.isSafari, true);
+        expect(browser.isInternetExplorer, false);
+        expect(browser.version, new Version(10, 1, 0));
+      });
+
+      test('only a major version', () {
+        Browser.navigator = testSafari(
+            userAgent: safariUserAgentWithoutMinorTestString,
+            appVersion: safariAppVersionWithoutMinorTestString);
+        Browser browser = Browser.getCurrentBrowser();
+        browser.clearVersion();
+
+        expect(browser.name, 'Safari');
+        expect(browser.isChrome, false);
+        expect(browser.isFirefox, false);
+        expect(browser.isSafari, true);
+        expect(browser.isInternetExplorer, false);
+        expect(browser.version, new Version(11, 0, 0));
+      });
     });
 
     test('WKWebView', () {

--- a/test/browser_test.dart
+++ b/test/browser_test.dart
@@ -91,7 +91,6 @@ void main() {
         Browser.navigator = testSafari(
             userAgent: safariUserAgentWithoutPatchTestString,
             appVersion: safariAppVersionWithoutPatchTestString);
-        print(Browser.navigator.userAgent);
         Browser browser = Browser.getCurrentBrowser();
         browser.clearVersion();
 

--- a/test/constants.dart
+++ b/test/constants.dart
@@ -24,6 +24,14 @@ const String safariUserAgentTestString =
     'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/601.7.8 (KHTML, like Gecko) Version/9.1.3 Safari/601.7.8';
 const String safariAppVersionTestString =
     '5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/601.7.8 (KHTML, like Gecko) Version/9.1.3 Safari/601.7.8';
+const String safariUserAgentWithoutPatchTestString =
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/601.7.8 (KHTML, like Gecko) Version/10.1 Safari/601.7.8';
+const String safariAppVersionWithoutPatchTestString =
+    '5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/601.7.8 (KHTML, like Gecko) Version/10.1 Safari/601.7.8';
+const String safariUserAgentWithoutMinorTestString =
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/601.7.8 (KHTML, like Gecko) Version/11 Safari/601.7.8';
+const String safariAppVersionWithoutMinorTestString =
+    '5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/601.7.8 (KHTML, like Gecko) Version/11 Safari/601.7.8';
 const String safariAppNameTestString = 'Netscape';
 const String safariVendorTestString = 'Apple Computer, Inc.';
 


### PR DESCRIPTION
After investigating an [Insight report](https://w-insight.appspot.com/hubble/Spreadsheet-prod/04-18-2017?search=platform_detect%2Fsrc%2Fbrowser.dart&source=hipchat-general&type=Uncaught%20exception&expanded=true&search-filter=Context) for platform_detect I discovered that Safari doesn't always include the patch.  Updated the version parsing to gracefully handle when the patch is missing and went ahead and covered the minor missing just for completeness.

@aaronlademann-wf @greglittlefield-wf @clairesarsam-wf @jayudey-wf 

FYI @Workiva/dt-data-sharing-squad 