### PR TITLE
WP-3971 Release platform_detect 1.3.1

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: platform_detect
 description: A lightweight library for detecting the running browser and OS
-version: 1.3.0
+version: 1.3.1
 author: Workiva Client Platform Team <team-clientplatform@workiva.com>
 homepage: https://github.com/Workiva/platform_detect
 documentation: https://www.dartdocs.org/documentation/platform_detect/latest


### PR DESCRIPTION

Pulls Included in Release:
* [WP-3994 Update version parsing to handle Safari's practice of omitting patch](https://github.com/Workiva/platform_detect/pull/20)


Requested by: @travissanderson-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/platform_detect/compare/1.3.0...version-bump-platform_detect-1-3-1
Diff Between Last Tag and New Tag: https://github.com/Workiva/platform_detect/compare/1.3.0...1.3.1