### PR TITLE
HY-4909 Turn on strong mode

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,0 +1,2 @@
+analyzer:
+  strong-mode: true

--- a/lib/src/decorator.dart
+++ b/lib/src/decorator.dart
@@ -114,7 +114,7 @@ String getPlatformClasses(
     {List<Feature> features,
     bool includeDefaults: true,
     List<String> existingClasses: const []}) {
-  var allFeatures = new Set.from(features ?? []);
+  var allFeatures = new Set<Feature>.from(features ?? []);
 
   if (includeDefaults) allFeatures.addAll(defaultFeatureCssClassDecorators);
 


### PR DESCRIPTION
In order to use the dart dev compiler, everything must be strong mode compliant. So, turn on strong mode analysis option and fix a type error.

# Testing
 - [ ] CI passes