### PR TITLE
WP-4851 Do not fail if valid chrome version is not found

### DIFF
--- a/lib/src/browser.dart
+++ b/lib/src/browser.dart
@@ -89,11 +89,15 @@ class _Chrome extends Browser {
   static Version _getVersion(NavigatorProvider navigator) {
     Match match = new RegExp(r"Chrome/(\d+)\.(\d+)\.(\d+)\.(\d+)\s")
         .firstMatch(navigator.appVersion);
-    var major = int.parse(match.group(1));
-    var minor = int.parse(match.group(2));
-    var patch = int.parse(match.group(3));
-    var build = match.group(4);
-    return new Version(major, minor, patch, build: build);
+    if (match != null) {
+      var major = int.parse(match.group(1));
+      var minor = int.parse(match.group(2));
+      var patch = int.parse(match.group(3));
+      var build = match.group(4);
+      return new Version(major, minor, patch, build: build);
+    } else {
+      return new Version(0, 0, 0);
+    }
   }
 }
 

--- a/test/browser_test.dart
+++ b/test/browser_test.dart
@@ -7,14 +7,17 @@ import 'package:platform_detect/src/navigator.dart';
 import './constants.dart';
 
 void main() {
+  Browser browser;
+
   group('browser detects', () {
     tearDown(() {
+      browser?.clearVersion();
       Browser.navigator = null;
     });
 
     test('Unknown Browser', () {
       Browser.navigator = new TestNavigator();
-      var browser = Browser.getCurrentBrowser();
+      browser = Browser.getCurrentBrowser();
       expect(browser.name, Browser.UnknownBrowser.name);
       expect(browser.version, Browser.UnknownBrowser.version);
       expect(browser.isChrome, false);
@@ -24,8 +27,7 @@ void main() {
     });
 
     test('Fake Browser', () {
-      Browser browser =
-          new Browser('Fake', (_) => true, (_) => new Version(1, 1, 0));
+      browser = new Browser('Fake', (_) => true, (_) => new Version(1, 1, 0));
       expect(browser.name, 'Fake');
       expect(browser.version, new Version(1, 1, 0));
       expect(browser.isChrome, false);
@@ -36,7 +38,7 @@ void main() {
 
     test('Chrome', () {
       Browser.navigator = testChrome();
-      Browser browser = Browser.getCurrentBrowser();
+      browser = Browser.getCurrentBrowser();
 
       expect(browser.name, 'Chrome');
       expect(browser.isChrome, true);
@@ -46,9 +48,20 @@ void main() {
       expect(browser.version, new Version(53, 0, 2785, build: '143'));
     });
 
+    test('Chromeless', () {
+      Browser.navigator = testChromeless();
+      browser = Browser.getCurrentBrowser();
+      expect(browser.name, 'Chrome');
+      expect(browser.isChrome, true);
+      expect(browser.isFirefox, false);
+      expect(browser.isSafari, false);
+      expect(browser.isInternetExplorer, false);
+      expect(browser.version, new Version(0, 0, 0));
+    });
+
     test('Internet Explorer', () {
       Browser.navigator = testInternetExplorer();
-      Browser browser = Browser.getCurrentBrowser();
+      browser = Browser.getCurrentBrowser();
 
       expect(browser.name, 'Internet Explorer');
       expect(browser.isChrome, false);
@@ -60,7 +73,7 @@ void main() {
 
     test('Firefox', () {
       Browser.navigator = testFirefox();
-      Browser browser = Browser.getCurrentBrowser();
+      browser = Browser.getCurrentBrowser();
 
       expect(browser.name, 'Firefox');
       expect(browser.isChrome, false);
@@ -77,7 +90,7 @@ void main() {
 
       test('major, minor and patch version', () {
         Browser.navigator = testSafari();
-        Browser browser = Browser.getCurrentBrowser();
+        browser = Browser.getCurrentBrowser();
 
         expect(browser.name, 'Safari');
         expect(browser.isChrome, false);
@@ -91,7 +104,7 @@ void main() {
         Browser.navigator = testSafari(
             userAgent: safariUserAgentWithoutPatchTestString,
             appVersion: safariAppVersionWithoutPatchTestString);
-        Browser browser = Browser.getCurrentBrowser();
+        browser = Browser.getCurrentBrowser();
         browser.clearVersion();
 
         expect(browser.name, 'Safari');
@@ -106,7 +119,7 @@ void main() {
         Browser.navigator = testSafari(
             userAgent: safariUserAgentWithoutMinorTestString,
             appVersion: safariAppVersionWithoutMinorTestString);
-        Browser browser = Browser.getCurrentBrowser();
+        browser = Browser.getCurrentBrowser();
         browser.clearVersion();
 
         expect(browser.name, 'Safari');
@@ -120,7 +133,7 @@ void main() {
 
     test('WKWebView', () {
       Browser.navigator = testWkWebView();
-      Browser browser = Browser.getCurrentBrowser();
+      browser = Browser.getCurrentBrowser();
 
       expect(browser.name, 'WKWebView');
       expect(browser.isChrome, false);

--- a/test/constants.dart
+++ b/test/constants.dart
@@ -7,6 +7,9 @@ const String chromeAppVersionTestString =
 const String chromeAppNameTestString = null;
 const String chromeVendorTestString = 'Google Inc.';
 
+const String chromelessUserAgentTestString = 'Chromeless 1.0.1';
+const String chromelessAppVersionTestString = 'Chromeless 1.0.1';
+
 const String firefoxUserAgentTestString =
     'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:48.0) Gecko/20100101 Firefox/48.0';
 const String firefoxAppVersionTestString = '5.0 (Macintosh)';
@@ -51,6 +54,19 @@ TestNavigator testChrome({
   return new TestNavigator()
     ..userAgent = userAgent
     ..appVersion = appVersion
+    ..appName = appName
+    ..vendor = vendor;
+}
+
+TestNavigator testChromeless({
+  userAgent: chromelessUserAgentTestString,
+  appVersion: chromelessAppVersionTestString,
+  appName: chromeAppNameTestString,
+  vendor: chromeVendorTestString,
+}) {
+  return new TestNavigator()
+    ..userAgent = chromelessUserAgentTestString
+    ..appVersion = chromelessAppVersionTestString
     ..appName = appName
     ..vendor = vendor;
 }


### PR DESCRIPTION
## Issue
- When trying to utilize the chromeless package, https://github.com/graphcool/chromeless, the chrome version provided by the tool causes an error b/c it's version number is formatted as x.x.x rather then x.x.x+x.

## Changes
**Source:**
- Added a branch to allow for a non-standard chrome version.

**Tests:**
- added

## Areas of Regression
- failing CI

## Testing
- passing CI

## Code Review
@Workiva/ui-platform-pp 
@Workiva/web-platform-pp 