### PR TITLE
Dart2 only and Dart 2.6 touch detection fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,8 @@
 # Files and directories created by pub
 .packages
-.pub/
+.dart_tool/
 build/
 coverage/
-packages
 pubspec.lock
 
 # Directory created by dartdoc

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: dart
 sudo: required
 dart:
-  - 1.24.3
-  - 2.0.0
+  - 2.4.1 # TODO: Remove this and bump the lower SDK bound to 2.6.1 once we've upgraded the ecosystem to it
+  - stable
 dart_task:
   - test: --platform vm
   - test: --platform chrome

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM google/dart:1.24.3 as build
+FROM drydock-prod.workiva.net/workiva/dart_build_image:1
 
 WORKDIR /build
 
@@ -13,6 +13,6 @@ ARG GIT_BRANCH
 
 RUN pub get
 
-ARG BUILD_ARTIFACTS_DART-DEPENDENCIES=/build/pubspec.lock
+ARG BUILD_ARTIFACTS_DART_PUBSPECLOCK=/build/pubspec.lock
 
 FROM scratch

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -421,12 +421,6 @@ linter:
     # 0 issues
     - prefer_asserts_in_initializer_lists
 
-    # Prefer using a boolean as the assert condition.
-    # http://dart-lang.github.io/linter/lints/prefer_bool_in_asserts.html
-    # recommendation: optional
-    # 0 issues
-    - prefer_bool_in_asserts
-
     # Use collection literals when possible.
     # http://dart-lang.github.io/linter/lints/prefer_collection_literals.html
     # recommendation: recommended
@@ -591,12 +585,6 @@ linter:
     # recommendation: optional
     # 0 issues
     - sort_unnamed_constructors_first
-
-    # Place the `super` call last in a constructor initialization list.
-    # http://dart-lang.github.io/linter/lints/super_goes_last.html
-    # recommendation: optional
-    # 0 issues
-    - super_goes_last
 
     # Test type arguments in operator ==(Object other).
     # http://dart-lang.github.io/linter/lints/test_types_in_equals.html

--- a/example/main.dart
+++ b/example/main.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 import 'dart:html';
 import 'package:platform_detect/platform_detect.dart';
 import 'package:platform_detect/src/decorator.dart';

--- a/example/main.dart
+++ b/example/main.dart
@@ -75,7 +75,7 @@ void _parseTestValues() {
   InputElement testAppNameInput = querySelector('#$testAppNameId');
   InputElement testUserAgentInput = querySelector('#$testUserAgentId');
 
-  var navigator = new TestNavigator();
+  var navigator = TestNavigator();
   navigator.vendor = testVendorInput.value.trim();
   navigator.appVersion = testAppVersionInput.value.trim();
   navigator.appName = testAppNameInput.value.trim();

--- a/lib/src/browser.dart
+++ b/lib/src/browser.dart
@@ -28,7 +28,7 @@ class Browser {
   @visibleForTesting
   clearVersion() => _version = null;
 
-  static Browser UnknownBrowser = new Browser('Unknown', null, null);
+  static Browser UnknownBrowser = Browser('Unknown', null, null);
 
   Browser(this.name, bool matchesNavigator(NavigatorProvider navigator),
       Version parseVersion(NavigatorProvider navigator),
@@ -50,7 +50,7 @@ class Browser {
       if (_parseVersion != null) {
         _version = _parseVersion(Browser.navigator);
       } else {
-        _version = new Version(0, 0, 0);
+        _version = Version(0, 0, 0);
       }
     }
 
@@ -72,11 +72,11 @@ class Browser {
   bool get isWKWebView => this == wkWebView;
 }
 
-Browser chrome = new _Chrome();
-Browser firefox = new _Firefox();
-Browser safari = new _Safari();
-Browser internetExplorer = new _InternetExplorer();
-Browser wkWebView = new _WKWebView();
+Browser chrome = _Chrome();
+Browser firefox = _Firefox();
+Browser safari = _Safari();
+Browser internetExplorer = _InternetExplorer();
+Browser wkWebView = _WKWebView();
 
 class _Chrome extends Browser {
   _Chrome() : super('Chrome', _isChrome, _getVersion);
@@ -87,16 +87,16 @@ class _Chrome extends Browser {
   }
 
   static Version _getVersion(NavigatorProvider navigator) {
-    Match match = new RegExp(r"Chrome/(\d+)\.(\d+)\.(\d+)\.(\d+)\s")
+    Match match = RegExp(r"Chrome/(\d+)\.(\d+)\.(\d+)\.(\d+)\s")
         .firstMatch(navigator.appVersion);
     if (match != null) {
       var major = int.parse(match.group(1));
       var minor = int.parse(match.group(2));
       var patch = int.parse(match.group(3));
       var build = match.group(4);
-      return new Version(major, minor, patch, build: build);
+      return Version(major, minor, patch, build: build);
     } else {
-      return new Version(0, 0, 0);
+      return Version(0, 0, 0);
     }
   }
 }
@@ -109,11 +109,10 @@ class _Firefox extends Browser {
   }
 
   static Version _getVersion(NavigatorProvider navigator) {
-    Match match =
-        new RegExp(r'rv:(\d+)\.(\d+)\)').firstMatch(navigator.userAgent);
+    Match match = RegExp(r'rv:(\d+)\.(\d+)\)').firstMatch(navigator.userAgent);
     var major = int.parse(match.group(1));
     var minor = int.parse(match.group(2));
-    return new Version(major, minor, 0);
+    return Version(major, minor, 0);
   }
 }
 
@@ -129,13 +128,13 @@ class _Safari extends Browser {
   }
 
   static Version _getVersion(NavigatorProvider navigator) {
-    Match match = new RegExp(r'Version/(\d+)(\.(\d+))?(\.(\d+))?')
+    Match match = RegExp(r'Version/(\d+)(\.(\d+))?(\.(\d+))?')
         .firstMatch(navigator.appVersion);
     var major = int.parse(match.group(1));
     var minor = int.parse(match.group(3) ?? '0');
     var patch = int.parse(match.group(5) ?? '0');
 
-    return new Version(major, minor, patch);
+    return Version(major, minor, patch);
   }
 }
 
@@ -151,12 +150,12 @@ class _WKWebView extends Browser {
   }
 
   static Version _getVersion(NavigatorProvider navigator) {
-    Match match = new RegExp(r'AppleWebKit/(\d+)\.(\d+)\.(\d+)')
+    Match match = RegExp(r'AppleWebKit/(\d+)\.(\d+)\.(\d+)')
         .firstMatch(navigator.appVersion);
     var major = int.parse(match.group(1));
     var minor = int.parse(match.group(2));
     var patch = int.parse(match.group(3));
-    return new Version(major, minor, patch);
+    return Version(major, minor, patch);
   }
 }
 
@@ -173,27 +172,27 @@ class _InternetExplorer extends Browser {
 
   static Version _getVersion(NavigatorProvider navigator) {
     Match match =
-        new RegExp(r'MSIE (\d+)\.(\d+);').firstMatch(navigator.appVersion);
+        RegExp(r'MSIE (\d+)\.(\d+);').firstMatch(navigator.appVersion);
     if (match != null) {
       var major = int.parse(match.group(1));
       var minor = int.parse(match.group(2));
-      return new Version(major, minor, 0);
+      return Version(major, minor, 0);
     }
 
-    match = new RegExp(r'rv[: ](\d+)\.(\d+)').firstMatch(navigator.appVersion);
+    match = RegExp(r'rv[: ](\d+)\.(\d+)').firstMatch(navigator.appVersion);
     if (match != null) {
       var major = int.parse(match.group(1));
       var minor = int.parse(match.group(2));
-      return new Version(major, minor, 0);
+      return Version(major, minor, 0);
     }
 
-    match = new RegExp(r'Edge/(\d+)\.(\d+)$').firstMatch(navigator.appVersion);
+    match = RegExp(r'Edge/(\d+)\.(\d+)$').firstMatch(navigator.appVersion);
     if (match != null) {
       var major = int.parse(match.group(1));
       var minor = int.parse(match.group(2));
-      return new Version(major, minor, 0);
+      return Version(major, minor, 0);
     }
 
-    return new Version(0, 0, 0);
+    return Version(0, 0, 0);
   }
 }

--- a/lib/src/browser.dart
+++ b/lib/src/browser.dart
@@ -33,8 +33,8 @@ class Browser {
   Browser(this.name, bool matchesNavigator(NavigatorProvider navigator),
       Version parseVersion(NavigatorProvider navigator),
       {this.className})
-      : this._matchesNavigator = matchesNavigator,
-        this._parseVersion = parseVersion;
+      : _matchesNavigator = matchesNavigator,
+        _parseVersion = parseVersion;
 
   final String name;
 

--- a/lib/src/decorator.dart
+++ b/lib/src/decorator.dart
@@ -114,7 +114,7 @@ String getPlatformClasses(
     {List<Feature> features,
     bool includeDefaults = true,
     List<String> existingClasses = const []}) {
-  var allFeatures = new Set<Feature>.from(features ?? []);
+  var allFeatures = Set<Feature>.from(features ?? []);
 
   if (includeDefaults) allFeatures.addAll(defaultFeatureCssClassDecorators);
 

--- a/lib/src/decorator.dart
+++ b/lib/src/decorator.dart
@@ -112,8 +112,8 @@ bool nodeHasBeenDecorated(Element rootNode) =>
 /// set [includeDefaults] to `false`.
 String getPlatformClasses(
     {List<Feature> features,
-    bool includeDefaults: true,
-    List<String> existingClasses: const []}) {
+    bool includeDefaults = true,
+    List<String> existingClasses = const []}) {
   var allFeatures = new Set<Feature>.from(features ?? []);
 
   if (includeDefaults) allFeatures.addAll(defaultFeatureCssClassDecorators);
@@ -137,7 +137,7 @@ String getPlatformClasses(
 /// By default, [rootNode] is [document.documentElement].
 void decorateRootNodeWithPlatformClasses(
     {List<Feature> features,
-    bool includeDefaults: true,
+    bool includeDefaults = true,
     Element rootNode,
     callback()}) {
   rootNode ??= document.documentElement;

--- a/lib/src/detect.dart
+++ b/lib/src/detect.dart
@@ -38,7 +38,7 @@ Browser _browser;
 /// Current browser info
 Browser get browser {
   if (_browser == null) {
-    Browser.navigator = new _HtmlNavigator();
+    Browser.navigator = _HtmlNavigator();
     _browser = Browser.getCurrentBrowser();
   }
 
@@ -50,7 +50,7 @@ OperatingSystem _operatingSystem;
 /// Current operating system info
 OperatingSystem get operatingSystem {
   if (_operatingSystem == null) {
-    OperatingSystem.navigator = new _HtmlNavigator();
+    OperatingSystem.navigator = _HtmlNavigator();
     _operatingSystem = OperatingSystem.getCurrentOperatingSystem();
   }
 

--- a/lib/src/operating_system.dart
+++ b/lib/src/operating_system.dart
@@ -23,7 +23,7 @@ class OperatingSystem {
         orElse: () => UnknownOS);
   }
 
-  static OperatingSystem UnknownOS = new OperatingSystem('Unknown', null);
+  static OperatingSystem UnknownOS = OperatingSystem('Unknown', null);
 
   final String name;
   final Function _matchesNavigator;
@@ -39,21 +39,19 @@ class OperatingSystem {
   get isWindows => this == windows;
 }
 
-OperatingSystem linux =
-    new OperatingSystem('Linux', (NavigatorProvider navigator) {
+OperatingSystem linux = OperatingSystem('Linux', (NavigatorProvider navigator) {
   return navigator.appVersion.contains('Linux');
 });
 
-OperatingSystem mac = new OperatingSystem('Mac', (NavigatorProvider navigator) {
+OperatingSystem mac = OperatingSystem('Mac', (NavigatorProvider navigator) {
   return navigator.appVersion.contains('Mac');
 });
 
-OperatingSystem unix =
-    new OperatingSystem('Unix', (NavigatorProvider navigator) {
+OperatingSystem unix = OperatingSystem('Unix', (NavigatorProvider navigator) {
   return navigator.appVersion.contains('X11');
 });
 
 OperatingSystem windows =
-    new OperatingSystem('Windows', (NavigatorProvider navigator) {
+    OperatingSystem('Windows', (NavigatorProvider navigator) {
   return navigator.appVersion.contains('Win');
 });

--- a/lib/src/operating_system.dart
+++ b/lib/src/operating_system.dart
@@ -29,7 +29,7 @@ class OperatingSystem {
   final Function _matchesNavigator;
 
   OperatingSystem(this.name, bool matchesNavigator(NavigatorProvider navigator))
-      : this._matchesNavigator = matchesNavigator;
+      : _matchesNavigator = matchesNavigator;
 
   static List<OperatingSystem> _knownSystems = [mac, windows, linux, unix];
 

--- a/lib/src/support.dart
+++ b/lib/src/support.dart
@@ -33,6 +33,9 @@ class Feature {
   @override
   bool operator ==(dynamic other) => other is Feature && other.name == name;
 
+  @override
+  int get hashCode => name.hashCode;
+
   Feature(this.name, this.isSupported);
 
   /// Whether the browser supports [TouchEvent]s.

--- a/lib/src/support.dart
+++ b/lib/src/support.dart
@@ -40,11 +40,11 @@ class Feature {
   /// Related: [msTouchEvents]
   ///
   /// See: [TouchEvent.supported]
-  static final Feature touchEvents = new Feature('touch', TouchEvent.supported);
+  static final Feature touchEvents = Feature('touch', TouchEvent.supported);
 
   /// Whether the internet explorer browser supports touch events.
   ///
   /// Related: [touchEvents]
-  static final Feature msTouchEvents = new Feature('mstouch',
+  static final Feature msTouchEvents = Feature('mstouch',
       browser.isInternetExplorer && window.navigator.maxTouchPoints > 1);
 }

--- a/lib/src/support.dart
+++ b/lib/src/support.dart
@@ -42,8 +42,21 @@ class Feature {
   ///
   /// Related: [msTouchEvents]
   ///
-  /// See: [TouchEvent.supported]
-  static final Feature touchEvents = Feature('touch', TouchEvent.supported);
+  /// As of Dart 2.5.0, [TouchEvent.supported] is always true on Chrome 70+,
+  /// even on non-touch devices.
+  ///
+  /// This feature checks whether maxTouchPoints is greater than 0
+  /// (if it exists, falling back to TouchEvent.supported),
+  /// which is the recommended way to check for touch screens.
+  ///
+  /// See:
+  /// - https://www.chromestatus.com/feature/4764225348042752
+  /// - https://github.com/dart-lang/sdk/commit/3a7101e16b48b67fc0a832444b06e79a169bce86
+  static final Feature touchEvents = Feature(
+      'touch',
+      window.navigator.maxTouchPoints != null
+          ? window.navigator.maxTouchPoints > 0
+          : TouchEvent.supported);
 
   /// Whether the internet explorer browser supports touch events.
   ///

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,14 +6,14 @@ homepage: https://github.com/Workiva/platform_detect
 documentation: https://www.dartdocs.org/documentation/platform_detect/latest
 
 environment:
-  sdk: '>=1.13.0 <3.0.0'
+  sdk: '>=2.4.0 <3.0.0'
 
 dependencies:
   meta: ^1.0.4
-  pub_semver: ^1.0.0
+  pub_semver: ^1.4.2
 
 dev_dependencies:
-  build_runner: ">=0.6.0 <1.0.0"
-  build_test: ">=0.9.0 <1.0.0"
-  build_web_compilers: ">=0.2.0 <1.0.0"
-  test: '>=0.12.30 <2.0.0'
+  build_runner: ^1.7.1
+  build_test: ^0.10.9
+  build_web_compilers: ^2.5.1
+  test: ^1.9.1

--- a/test/browser_test.dart
+++ b/test/browser_test.dart
@@ -16,7 +16,7 @@ void main() {
     });
 
     test('Unknown Browser', () {
-      Browser.navigator = new TestNavigator();
+      Browser.navigator = TestNavigator();
       browser = Browser.getCurrentBrowser();
       expect(browser.name, Browser.UnknownBrowser.name);
       expect(browser.version, Browser.UnknownBrowser.version);
@@ -27,9 +27,9 @@ void main() {
     });
 
     test('Fake Browser', () {
-      browser = new Browser('Fake', (_) => true, (_) => new Version(1, 1, 0));
+      browser = Browser('Fake', (_) => true, (_) => Version(1, 1, 0));
       expect(browser.name, 'Fake');
-      expect(browser.version, new Version(1, 1, 0));
+      expect(browser.version, Version(1, 1, 0));
       expect(browser.isChrome, false);
       expect(browser.isFirefox, false);
       expect(browser.isSafari, false);
@@ -45,7 +45,7 @@ void main() {
       expect(browser.isFirefox, false);
       expect(browser.isSafari, false);
       expect(browser.isInternetExplorer, false);
-      expect(browser.version, new Version(53, 0, 2785, build: '143'));
+      expect(browser.version, Version(53, 0, 2785, build: '143'));
     });
 
     test('Chromeless', () {
@@ -56,7 +56,7 @@ void main() {
       expect(browser.isFirefox, false);
       expect(browser.isSafari, false);
       expect(browser.isInternetExplorer, false);
-      expect(browser.version, new Version(0, 0, 0));
+      expect(browser.version, Version(0, 0, 0));
     });
 
     test('Internet Explorer', () {
@@ -68,7 +68,7 @@ void main() {
       expect(browser.isFirefox, false);
       expect(browser.isSafari, false);
       expect(browser.isInternetExplorer, true);
-      expect(browser.version, new Version(11, 0, 0));
+      expect(browser.version, Version(11, 0, 0));
     });
 
     test('Firefox', () {
@@ -80,7 +80,7 @@ void main() {
       expect(browser.isFirefox, true);
       expect(browser.isSafari, false);
       expect(browser.isInternetExplorer, false);
-      expect(browser.version, new Version(48, 0, 0));
+      expect(browser.version, Version(48, 0, 0));
     });
 
     group('Safari', () {
@@ -97,7 +97,7 @@ void main() {
         expect(browser.isFirefox, false);
         expect(browser.isSafari, true);
         expect(browser.isInternetExplorer, false);
-        expect(browser.version, new Version(9, 1, 3));
+        expect(browser.version, Version(9, 1, 3));
       });
 
       test('major and minor version', () {
@@ -112,7 +112,7 @@ void main() {
         expect(browser.isFirefox, false);
         expect(browser.isSafari, true);
         expect(browser.isInternetExplorer, false);
-        expect(browser.version, new Version(10, 1, 0));
+        expect(browser.version, Version(10, 1, 0));
       });
 
       test('only a major version', () {
@@ -127,7 +127,7 @@ void main() {
         expect(browser.isFirefox, false);
         expect(browser.isSafari, true);
         expect(browser.isInternetExplorer, false);
-        expect(browser.version, new Version(11, 0, 0));
+        expect(browser.version, Version(11, 0, 0));
       });
     });
 
@@ -141,7 +141,7 @@ void main() {
       expect(browser.isSafari, false);
       expect(browser.isWKWebView, true);
       expect(browser.isInternetExplorer, false);
-      expect(browser.version, new Version(601, 7, 8));
+      expect(browser.version, Version(601, 7, 8));
     });
   });
 }

--- a/test/constants.dart
+++ b/test/constants.dart
@@ -46,10 +46,10 @@ const String wkWebViewAppNameTestString = 'Netscape';
 const String wkWebViewVendorTestString = 'Apple Computer, Inc.';
 
 TestNavigator testChrome({
-  userAgent: chromeUserAgentTestString,
-  appVersion: chromeAppVersionTestString,
-  appName: chromeAppNameTestString,
-  vendor: chromeVendorTestString,
+  userAgent = chromeUserAgentTestString,
+  appVersion = chromeAppVersionTestString,
+  appName = chromeAppNameTestString,
+  vendor = chromeVendorTestString,
 }) {
   return new TestNavigator()
     ..userAgent = userAgent
@@ -59,10 +59,10 @@ TestNavigator testChrome({
 }
 
 TestNavigator testChromeless({
-  userAgent: chromelessUserAgentTestString,
-  appVersion: chromelessAppVersionTestString,
-  appName: chromeAppNameTestString,
-  vendor: chromeVendorTestString,
+  userAgent = chromelessUserAgentTestString,
+  appVersion = chromelessAppVersionTestString,
+  appName = chromeAppNameTestString,
+  vendor = chromeVendorTestString,
 }) {
   return new TestNavigator()
     ..userAgent = chromelessUserAgentTestString
@@ -72,10 +72,10 @@ TestNavigator testChromeless({
 }
 
 TestNavigator testFirefox({
-  userAgent: firefoxUserAgentTestString,
-  appVersion: firefoxAppVersionTestString,
-  appName: firefoxAppNameTestString,
-  vendor: firefoxVendorTestString,
+  userAgent = firefoxUserAgentTestString,
+  appVersion = firefoxAppVersionTestString,
+  appName = firefoxAppNameTestString,
+  vendor = firefoxVendorTestString,
 }) {
   return new TestNavigator()
     ..userAgent = userAgent
@@ -85,10 +85,10 @@ TestNavigator testFirefox({
 }
 
 TestNavigator testInternetExplorer({
-  userAgent: ieUserAgentTestString,
-  appVersion: ieAppVersionTestString,
-  appName: ieAppNameTestString,
-  vendor: ieVendorTestString,
+  userAgent = ieUserAgentTestString,
+  appVersion = ieAppVersionTestString,
+  appName = ieAppNameTestString,
+  vendor = ieVendorTestString,
 }) {
   return new TestNavigator()
     ..userAgent = userAgent
@@ -98,10 +98,10 @@ TestNavigator testInternetExplorer({
 }
 
 TestNavigator testSafari({
-  userAgent: safariUserAgentTestString,
-  appVersion: safariAppVersionTestString,
-  appName: safariAppNameTestString,
-  vendor: safariVendorTestString,
+  userAgent = safariUserAgentTestString,
+  appVersion = safariAppVersionTestString,
+  appName = safariAppNameTestString,
+  vendor = safariVendorTestString,
 }) {
   return new TestNavigator()
     ..userAgent = userAgent
@@ -111,10 +111,10 @@ TestNavigator testSafari({
 }
 
 TestNavigator testWkWebView({
-  userAgent: wkWebViewUserAgentTestString,
-  appVersion: wkWebViewAppVersionTestString,
-  appName: wkWebViewAppNameTestString,
-  vendor: wkWebViewVendorTestString,
+  userAgent = wkWebViewUserAgentTestString,
+  appVersion = wkWebViewAppVersionTestString,
+  appName = wkWebViewAppNameTestString,
+  vendor = wkWebViewVendorTestString,
 }) {
   return new TestNavigator()
     ..userAgent = userAgent

--- a/test/constants.dart
+++ b/test/constants.dart
@@ -51,7 +51,7 @@ TestNavigator testChrome({
   appName = chromeAppNameTestString,
   vendor = chromeVendorTestString,
 }) {
-  return new TestNavigator()
+  return TestNavigator()
     ..userAgent = userAgent
     ..appVersion = appVersion
     ..appName = appName
@@ -64,7 +64,7 @@ TestNavigator testChromeless({
   appName = chromeAppNameTestString,
   vendor = chromeVendorTestString,
 }) {
-  return new TestNavigator()
+  return TestNavigator()
     ..userAgent = chromelessUserAgentTestString
     ..appVersion = chromelessAppVersionTestString
     ..appName = appName
@@ -77,7 +77,7 @@ TestNavigator testFirefox({
   appName = firefoxAppNameTestString,
   vendor = firefoxVendorTestString,
 }) {
-  return new TestNavigator()
+  return TestNavigator()
     ..userAgent = userAgent
     ..appVersion = appVersion
     ..appName = appName
@@ -90,7 +90,7 @@ TestNavigator testInternetExplorer({
   appName = ieAppNameTestString,
   vendor = ieVendorTestString,
 }) {
-  return new TestNavigator()
+  return TestNavigator()
     ..userAgent = userAgent
     ..appVersion = appVersion
     ..appName = appName
@@ -103,7 +103,7 @@ TestNavigator testSafari({
   appName = safariAppNameTestString,
   vendor = safariVendorTestString,
 }) {
-  return new TestNavigator()
+  return TestNavigator()
     ..userAgent = userAgent
     ..appVersion = appVersion
     ..appName = appName
@@ -116,7 +116,7 @@ TestNavigator testWkWebView({
   appName = wkWebViewAppNameTestString,
   vendor = wkWebViewVendorTestString,
 }) {
-  return new TestNavigator()
+  return TestNavigator()
     ..userAgent = userAgent
     ..appVersion = appVersion
     ..appName = appName

--- a/test/decorator_test.dart
+++ b/test/decorator_test.dart
@@ -18,7 +18,7 @@ void main() {
 
     void sharedSetup() {
       calls = [];
-      fakeRootNode = new DivElement();
+      fakeRootNode = DivElement();
     }
 
     tearDown(() {
@@ -77,7 +77,7 @@ void main() {
     group('should identify feature support:', () {
       void assertFakeRootNode() {
         if (fakeRootNode == null) {
-          throw new AssertionError(
+          throw AssertionError(
               '`fakeRootNodeClasses` must be set before calling `verifyDistinctFeatureCssClasses`.');
         }
       }
@@ -108,7 +108,7 @@ void main() {
           // 1. Ensure that its there
           expect(
               fakeRootNode.classes,
-              contains(matches(new RegExp(
+              contains(matches(RegExp(
                   '($featureSupportNegationClassPrefix)*${features[i].name}'))));
         }
 
@@ -129,14 +129,14 @@ void main() {
 
       group('custom features provided by the consumer', () {
         Feature uniqueConsumerFeature =
-            new Feature('canvas', new CanvasElement().context2D != null);
+            Feature('canvas', CanvasElement().context2D != null);
         List<Feature> consumerFeaturesThatContainsNoDefaults = [
           uniqueConsumerFeature
         ];
         List<Feature> consumerFeaturesThatMatchesDefaults =
-            new List.from(defaultFeatureCssClassDecorators);
+            List.from(defaultFeatureCssClassDecorators);
         List<Feature> consumerFeaturesThatContainsDefaults =
-            new List.from(defaultFeatureCssClassDecorators)
+            List.from(defaultFeatureCssClassDecorators)
               ..add(uniqueConsumerFeature);
 
         group(
@@ -148,9 +148,8 @@ void main() {
                 rootNode: fakeRootNode,
                 callback: callback);
 
-            verifyFeatureCssClasses(
-                new List.from(defaultFeatureCssClassDecorators)
-                  ..addAll(consumerFeaturesThatContainsNoDefaults));
+            verifyFeatureCssClasses(List.from(defaultFeatureCssClassDecorators)
+              ..addAll(consumerFeaturesThatContainsNoDefaults));
           });
 
           test('and `includeDefaults` is set to `false`', () {

--- a/test/operating_system_test.dart
+++ b/test/operating_system_test.dart
@@ -4,10 +4,10 @@ import 'package:test/test.dart';
 import 'package:platform_detect/src/navigator.dart';
 import 'package:platform_detect/src/operating_system.dart';
 
-final linux = new TestNavigator()..appVersion = 'Linux';
-final mac = new TestNavigator()..appVersion = 'Macintosh';
-final unix = new TestNavigator()..appVersion = 'X11';
-final windows = new TestNavigator()..appVersion = 'Windows';
+final linux = TestNavigator()..appVersion = 'Linux';
+final mac = TestNavigator()..appVersion = 'Macintosh';
+final unix = TestNavigator()..appVersion = 'X11';
+final windows = TestNavigator()..appVersion = 'Windows';
 
 void main() {
   group('operating system detects', () {
@@ -16,7 +16,7 @@ void main() {
     });
 
     test('Unknown Operating System', () {
-      OperatingSystem.navigator = new TestNavigator();
+      OperatingSystem.navigator = TestNavigator();
       var os = OperatingSystem.getCurrentOperatingSystem();
       expect(os.name, OperatingSystem.UnknownOS.name);
       expect(os.isMac, false);

--- a/test/support_test.dart
+++ b/test/support_test.dart
@@ -1,0 +1,11 @@
+@TestOn('browser')
+import 'package:platform_detect/src/support.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Feature.touchEvents', () {
+    test('is false on Chrome desktop (which we can assume CI is using)', () {
+      expect(Feature.touchEvents.isSupported, isFalse);
+    }, testOn: 'chrome');
+  });
+}


### PR DESCRIPTION
## Problem
As of Dart 2.5.0, `TouchEvent.supported` is always true on Chrome 70+, even on non-touch devices, causing the value of `Feature.touchEvents` tochange.

This causes things that rely Feature.touchEvents`) to break when moving from 2.4.1 to 2.6.0.

## Solution
Update check to be whether `navigator.maxTouchPoints > 0`(if `maxTouchPoints exists, falling back to TouchEvent.supported), which is the recommended way to check for touch screens.

 See:
 - https://www.chromestatus.com/feature/4764225348042752
 - https://github.com/dart-lang/sdk/commit/3a7101e16b48b67fc0a832444b06e79a169bce86

## Boyscouting
(Best reviewed separately)
- Transition repo to be Dart 2 only and perform cleanup
- Add missing `Feature.hashCode` implementation

## Release Notes
Fix `Feature.touchEvents` to return false on desktop Chrome and other browsers with a `navigator.maxTouchPoints` of 0.

## QA Instructions
- Verify that regression test added in https://github.com/Workiva/platform_detect/pull/42/commits/3d5753eac2742b6a11923e1158cf600cc4bd4f81 is failing in the Dart 2.6 Travis build, and passing in the latest commit
- Verify tests pass