### PR TITLE
CPLAT-8329: Post-Dart2 cleanup

### DIFF
--- a/example/main.dart
+++ b/example/main.dart
@@ -75,7 +75,7 @@ void _parseTestValues() {
   InputElement testAppNameInput = querySelector('#$testAppNameId');
   InputElement testUserAgentInput = querySelector('#$testUserAgentId');
 
-  var navigator = new TestNavigator();
+  var navigator = TestNavigator();
   navigator.vendor = testVendorInput.value.trim();
   navigator.appVersion = testAppVersionInput.value.trim();
   navigator.appName = testAppNameInput.value.trim();

--- a/lib/src/browser.dart
+++ b/lib/src/browser.dart
@@ -28,7 +28,7 @@ class Browser {
   @visibleForTesting
   clearVersion() => _version = null;
 
-  static Browser UnknownBrowser = new Browser('Unknown', null, null);
+  static Browser UnknownBrowser = Browser('Unknown', null, null);
 
   Browser(this.name, bool matchesNavigator(NavigatorProvider navigator),
       Version parseVersion(NavigatorProvider navigator),
@@ -50,7 +50,7 @@ class Browser {
       if (_parseVersion != null) {
         _version = _parseVersion(Browser.navigator);
       } else {
-        _version = new Version(0, 0, 0);
+        _version = Version(0, 0, 0);
       }
     }
 
@@ -72,11 +72,11 @@ class Browser {
   bool get isWKWebView => this == wkWebView;
 }
 
-Browser chrome = new _Chrome();
-Browser firefox = new _Firefox();
-Browser safari = new _Safari();
-Browser internetExplorer = new _InternetExplorer();
-Browser wkWebView = new _WKWebView();
+Browser chrome = _Chrome();
+Browser firefox = _Firefox();
+Browser safari = _Safari();
+Browser internetExplorer = _InternetExplorer();
+Browser wkWebView = _WKWebView();
 
 class _Chrome extends Browser {
   _Chrome() : super('Chrome', _isChrome, _getVersion);
@@ -87,16 +87,16 @@ class _Chrome extends Browser {
   }
 
   static Version _getVersion(NavigatorProvider navigator) {
-    Match match = new RegExp(r"Chrome/(\d+)\.(\d+)\.(\d+)\.(\d+)\s")
+    Match match = RegExp(r"Chrome/(\d+)\.(\d+)\.(\d+)\.(\d+)\s")
         .firstMatch(navigator.appVersion);
     if (match != null) {
       var major = int.parse(match.group(1));
       var minor = int.parse(match.group(2));
       var patch = int.parse(match.group(3));
       var build = match.group(4);
-      return new Version(major, minor, patch, build: build);
+      return Version(major, minor, patch, build: build);
     } else {
-      return new Version(0, 0, 0);
+      return Version(0, 0, 0);
     }
   }
 }
@@ -109,11 +109,10 @@ class _Firefox extends Browser {
   }
 
   static Version _getVersion(NavigatorProvider navigator) {
-    Match match =
-        new RegExp(r'rv:(\d+)\.(\d+)\)').firstMatch(navigator.userAgent);
+    Match match = RegExp(r'rv:(\d+)\.(\d+)\)').firstMatch(navigator.userAgent);
     var major = int.parse(match.group(1));
     var minor = int.parse(match.group(2));
-    return new Version(major, minor, 0);
+    return Version(major, minor, 0);
   }
 }
 
@@ -129,13 +128,13 @@ class _Safari extends Browser {
   }
 
   static Version _getVersion(NavigatorProvider navigator) {
-    Match match = new RegExp(r'Version/(\d+)(\.(\d+))?(\.(\d+))?')
+    Match match = RegExp(r'Version/(\d+)(\.(\d+))?(\.(\d+))?')
         .firstMatch(navigator.appVersion);
     var major = int.parse(match.group(1));
     var minor = int.parse(match.group(3) ?? '0');
     var patch = int.parse(match.group(5) ?? '0');
 
-    return new Version(major, minor, patch);
+    return Version(major, minor, patch);
   }
 }
 
@@ -151,12 +150,12 @@ class _WKWebView extends Browser {
   }
 
   static Version _getVersion(NavigatorProvider navigator) {
-    Match match = new RegExp(r'AppleWebKit/(\d+)\.(\d+)\.(\d+)')
+    Match match = RegExp(r'AppleWebKit/(\d+)\.(\d+)\.(\d+)')
         .firstMatch(navigator.appVersion);
     var major = int.parse(match.group(1));
     var minor = int.parse(match.group(2));
     var patch = int.parse(match.group(3));
-    return new Version(major, minor, patch);
+    return Version(major, minor, patch);
   }
 }
 
@@ -173,27 +172,27 @@ class _InternetExplorer extends Browser {
 
   static Version _getVersion(NavigatorProvider navigator) {
     Match match =
-        new RegExp(r'MSIE (\d+)\.(\d+);').firstMatch(navigator.appVersion);
+        RegExp(r'MSIE (\d+)\.(\d+);').firstMatch(navigator.appVersion);
     if (match != null) {
       var major = int.parse(match.group(1));
       var minor = int.parse(match.group(2));
-      return new Version(major, minor, 0);
+      return Version(major, minor, 0);
     }
 
-    match = new RegExp(r'rv[: ](\d+)\.(\d+)').firstMatch(navigator.appVersion);
+    match = RegExp(r'rv[: ](\d+)\.(\d+)').firstMatch(navigator.appVersion);
     if (match != null) {
       var major = int.parse(match.group(1));
       var minor = int.parse(match.group(2));
-      return new Version(major, minor, 0);
+      return Version(major, minor, 0);
     }
 
-    match = new RegExp(r'Edge/(\d+)\.(\d+)$').firstMatch(navigator.appVersion);
+    match = RegExp(r'Edge/(\d+)\.(\d+)$').firstMatch(navigator.appVersion);
     if (match != null) {
       var major = int.parse(match.group(1));
       var minor = int.parse(match.group(2));
-      return new Version(major, minor, 0);
+      return Version(major, minor, 0);
     }
 
-    return new Version(0, 0, 0);
+    return Version(0, 0, 0);
   }
 }

--- a/lib/src/decorator.dart
+++ b/lib/src/decorator.dart
@@ -114,7 +114,7 @@ String getPlatformClasses(
     {List<Feature> features,
     bool includeDefaults = true,
     List<String> existingClasses = const []}) {
-  var allFeatures = new Set<Feature>.from(features ?? []);
+  var allFeatures = Set<Feature>.from(features ?? []);
 
   if (includeDefaults) allFeatures.addAll(defaultFeatureCssClassDecorators);
 

--- a/lib/src/decorator.dart
+++ b/lib/src/decorator.dart
@@ -112,8 +112,8 @@ bool nodeHasBeenDecorated(Element rootNode) =>
 /// set [includeDefaults] to `false`.
 String getPlatformClasses(
     {List<Feature> features,
-    bool includeDefaults: true,
-    List<String> existingClasses: const []}) {
+    bool includeDefaults = true,
+    List<String> existingClasses = const []}) {
   var allFeatures = new Set<Feature>.from(features ?? []);
 
   if (includeDefaults) allFeatures.addAll(defaultFeatureCssClassDecorators);
@@ -137,7 +137,7 @@ String getPlatformClasses(
 /// By default, [rootNode] is [document.documentElement].
 void decorateRootNodeWithPlatformClasses(
     {List<Feature> features,
-    bool includeDefaults: true,
+    bool includeDefaults = true,
     Element rootNode,
     callback()}) {
   rootNode ??= document.documentElement;

--- a/lib/src/detect.dart
+++ b/lib/src/detect.dart
@@ -38,7 +38,7 @@ Browser _browser;
 /// Current browser info
 Browser get browser {
   if (_browser == null) {
-    Browser.navigator = new _HtmlNavigator();
+    Browser.navigator = _HtmlNavigator();
     _browser = Browser.getCurrentBrowser();
   }
 
@@ -50,7 +50,7 @@ OperatingSystem _operatingSystem;
 /// Current operating system info
 OperatingSystem get operatingSystem {
   if (_operatingSystem == null) {
-    OperatingSystem.navigator = new _HtmlNavigator();
+    OperatingSystem.navigator = _HtmlNavigator();
     _operatingSystem = OperatingSystem.getCurrentOperatingSystem();
   }
 

--- a/lib/src/operating_system.dart
+++ b/lib/src/operating_system.dart
@@ -23,7 +23,7 @@ class OperatingSystem {
         orElse: () => UnknownOS);
   }
 
-  static OperatingSystem UnknownOS = new OperatingSystem('Unknown', null);
+  static OperatingSystem UnknownOS = OperatingSystem('Unknown', null);
 
   final String name;
   final Function _matchesNavigator;
@@ -39,21 +39,19 @@ class OperatingSystem {
   get isWindows => this == windows;
 }
 
-OperatingSystem linux =
-    new OperatingSystem('Linux', (NavigatorProvider navigator) {
+OperatingSystem linux = OperatingSystem('Linux', (NavigatorProvider navigator) {
   return navigator.appVersion.contains('Linux');
 });
 
-OperatingSystem mac = new OperatingSystem('Mac', (NavigatorProvider navigator) {
+OperatingSystem mac = OperatingSystem('Mac', (NavigatorProvider navigator) {
   return navigator.appVersion.contains('Mac');
 });
 
-OperatingSystem unix =
-    new OperatingSystem('Unix', (NavigatorProvider navigator) {
+OperatingSystem unix = OperatingSystem('Unix', (NavigatorProvider navigator) {
   return navigator.appVersion.contains('X11');
 });
 
 OperatingSystem windows =
-    new OperatingSystem('Windows', (NavigatorProvider navigator) {
+    OperatingSystem('Windows', (NavigatorProvider navigator) {
   return navigator.appVersion.contains('Win');
 });

--- a/lib/src/support.dart
+++ b/lib/src/support.dart
@@ -40,11 +40,11 @@ class Feature {
   /// Related: [msTouchEvents]
   ///
   /// See: [TouchEvent.supported]
-  static final Feature touchEvents = new Feature('touch', TouchEvent.supported);
+  static final Feature touchEvents = Feature('touch', TouchEvent.supported);
 
   /// Whether the internet explorer browser supports touch events.
   ///
   /// Related: [touchEvents]
-  static final Feature msTouchEvents = new Feature('mstouch',
+  static final Feature msTouchEvents = Feature('mstouch',
       browser.isInternetExplorer && window.navigator.maxTouchPoints > 1);
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,14 +6,14 @@ homepage: https://github.com/Workiva/platform_detect
 documentation: https://www.dartdocs.org/documentation/platform_detect/latest
 
 environment:
-  sdk: '>=1.13.0 <3.0.0'
+  sdk: '>=2.4.0 <3.0.0'
 
 dependencies:
   meta: ^1.0.4
-  pub_semver: ^1.0.0
+  pub_semver: ^1.4.2
 
 dev_dependencies:
-  build_runner: ">=0.6.0 <1.0.0"
-  build_test: ">=0.9.0 <1.0.0"
-  build_web_compilers: ">=0.2.0 <1.0.0"
-  test: '>=0.12.30 <2.0.0'
+  build_runner: ^1.7.1
+  build_test: ^0.10.9
+  build_web_compilers: ^2.5.1
+  test: ^1.9.1

--- a/test/browser_test.dart
+++ b/test/browser_test.dart
@@ -16,7 +16,7 @@ void main() {
     });
 
     test('Unknown Browser', () {
-      Browser.navigator = new TestNavigator();
+      Browser.navigator = TestNavigator();
       browser = Browser.getCurrentBrowser();
       expect(browser.name, Browser.UnknownBrowser.name);
       expect(browser.version, Browser.UnknownBrowser.version);
@@ -27,9 +27,9 @@ void main() {
     });
 
     test('Fake Browser', () {
-      browser = new Browser('Fake', (_) => true, (_) => new Version(1, 1, 0));
+      browser = Browser('Fake', (_) => true, (_) => Version(1, 1, 0));
       expect(browser.name, 'Fake');
-      expect(browser.version, new Version(1, 1, 0));
+      expect(browser.version, Version(1, 1, 0));
       expect(browser.isChrome, false);
       expect(browser.isFirefox, false);
       expect(browser.isSafari, false);
@@ -45,7 +45,7 @@ void main() {
       expect(browser.isFirefox, false);
       expect(browser.isSafari, false);
       expect(browser.isInternetExplorer, false);
-      expect(browser.version, new Version(53, 0, 2785, build: '143'));
+      expect(browser.version, Version(53, 0, 2785, build: '143'));
     });
 
     test('Chromeless', () {
@@ -56,7 +56,7 @@ void main() {
       expect(browser.isFirefox, false);
       expect(browser.isSafari, false);
       expect(browser.isInternetExplorer, false);
-      expect(browser.version, new Version(0, 0, 0));
+      expect(browser.version, Version(0, 0, 0));
     });
 
     test('Internet Explorer', () {
@@ -68,7 +68,7 @@ void main() {
       expect(browser.isFirefox, false);
       expect(browser.isSafari, false);
       expect(browser.isInternetExplorer, true);
-      expect(browser.version, new Version(11, 0, 0));
+      expect(browser.version, Version(11, 0, 0));
     });
 
     test('Firefox', () {
@@ -80,7 +80,7 @@ void main() {
       expect(browser.isFirefox, true);
       expect(browser.isSafari, false);
       expect(browser.isInternetExplorer, false);
-      expect(browser.version, new Version(48, 0, 0));
+      expect(browser.version, Version(48, 0, 0));
     });
 
     group('Safari', () {
@@ -97,7 +97,7 @@ void main() {
         expect(browser.isFirefox, false);
         expect(browser.isSafari, true);
         expect(browser.isInternetExplorer, false);
-        expect(browser.version, new Version(9, 1, 3));
+        expect(browser.version, Version(9, 1, 3));
       });
 
       test('major and minor version', () {
@@ -112,7 +112,7 @@ void main() {
         expect(browser.isFirefox, false);
         expect(browser.isSafari, true);
         expect(browser.isInternetExplorer, false);
-        expect(browser.version, new Version(10, 1, 0));
+        expect(browser.version, Version(10, 1, 0));
       });
 
       test('only a major version', () {
@@ -127,7 +127,7 @@ void main() {
         expect(browser.isFirefox, false);
         expect(browser.isSafari, true);
         expect(browser.isInternetExplorer, false);
-        expect(browser.version, new Version(11, 0, 0));
+        expect(browser.version, Version(11, 0, 0));
       });
     });
 
@@ -141,7 +141,7 @@ void main() {
       expect(browser.isSafari, false);
       expect(browser.isWKWebView, true);
       expect(browser.isInternetExplorer, false);
-      expect(browser.version, new Version(601, 7, 8));
+      expect(browser.version, Version(601, 7, 8));
     });
   });
 }

--- a/test/constants.dart
+++ b/test/constants.dart
@@ -46,10 +46,10 @@ const String wkWebViewAppNameTestString = 'Netscape';
 const String wkWebViewVendorTestString = 'Apple Computer, Inc.';
 
 TestNavigator testChrome({
-  userAgent: chromeUserAgentTestString,
-  appVersion: chromeAppVersionTestString,
-  appName: chromeAppNameTestString,
-  vendor: chromeVendorTestString,
+  userAgent = chromeUserAgentTestString,
+  appVersion = chromeAppVersionTestString,
+  appName = chromeAppNameTestString,
+  vendor = chromeVendorTestString,
 }) {
   return new TestNavigator()
     ..userAgent = userAgent
@@ -59,10 +59,10 @@ TestNavigator testChrome({
 }
 
 TestNavigator testChromeless({
-  userAgent: chromelessUserAgentTestString,
-  appVersion: chromelessAppVersionTestString,
-  appName: chromeAppNameTestString,
-  vendor: chromeVendorTestString,
+  userAgent = chromelessUserAgentTestString,
+  appVersion = chromelessAppVersionTestString,
+  appName = chromeAppNameTestString,
+  vendor = chromeVendorTestString,
 }) {
   return new TestNavigator()
     ..userAgent = chromelessUserAgentTestString
@@ -72,10 +72,10 @@ TestNavigator testChromeless({
 }
 
 TestNavigator testFirefox({
-  userAgent: firefoxUserAgentTestString,
-  appVersion: firefoxAppVersionTestString,
-  appName: firefoxAppNameTestString,
-  vendor: firefoxVendorTestString,
+  userAgent = firefoxUserAgentTestString,
+  appVersion = firefoxAppVersionTestString,
+  appName = firefoxAppNameTestString,
+  vendor = firefoxVendorTestString,
 }) {
   return new TestNavigator()
     ..userAgent = userAgent
@@ -85,10 +85,10 @@ TestNavigator testFirefox({
 }
 
 TestNavigator testInternetExplorer({
-  userAgent: ieUserAgentTestString,
-  appVersion: ieAppVersionTestString,
-  appName: ieAppNameTestString,
-  vendor: ieVendorTestString,
+  userAgent = ieUserAgentTestString,
+  appVersion = ieAppVersionTestString,
+  appName = ieAppNameTestString,
+  vendor = ieVendorTestString,
 }) {
   return new TestNavigator()
     ..userAgent = userAgent
@@ -98,10 +98,10 @@ TestNavigator testInternetExplorer({
 }
 
 TestNavigator testSafari({
-  userAgent: safariUserAgentTestString,
-  appVersion: safariAppVersionTestString,
-  appName: safariAppNameTestString,
-  vendor: safariVendorTestString,
+  userAgent = safariUserAgentTestString,
+  appVersion = safariAppVersionTestString,
+  appName = safariAppNameTestString,
+  vendor = safariVendorTestString,
 }) {
   return new TestNavigator()
     ..userAgent = userAgent
@@ -111,10 +111,10 @@ TestNavigator testSafari({
 }
 
 TestNavigator testWkWebView({
-  userAgent: wkWebViewUserAgentTestString,
-  appVersion: wkWebViewAppVersionTestString,
-  appName: wkWebViewAppNameTestString,
-  vendor: wkWebViewVendorTestString,
+  userAgent = wkWebViewUserAgentTestString,
+  appVersion = wkWebViewAppVersionTestString,
+  appName = wkWebViewAppNameTestString,
+  vendor = wkWebViewVendorTestString,
 }) {
   return new TestNavigator()
     ..userAgent = userAgent

--- a/test/constants.dart
+++ b/test/constants.dart
@@ -51,7 +51,7 @@ TestNavigator testChrome({
   appName = chromeAppNameTestString,
   vendor = chromeVendorTestString,
 }) {
-  return new TestNavigator()
+  return TestNavigator()
     ..userAgent = userAgent
     ..appVersion = appVersion
     ..appName = appName
@@ -64,7 +64,7 @@ TestNavigator testChromeless({
   appName = chromeAppNameTestString,
   vendor = chromeVendorTestString,
 }) {
-  return new TestNavigator()
+  return TestNavigator()
     ..userAgent = chromelessUserAgentTestString
     ..appVersion = chromelessAppVersionTestString
     ..appName = appName
@@ -77,7 +77,7 @@ TestNavigator testFirefox({
   appName = firefoxAppNameTestString,
   vendor = firefoxVendorTestString,
 }) {
-  return new TestNavigator()
+  return TestNavigator()
     ..userAgent = userAgent
     ..appVersion = appVersion
     ..appName = appName
@@ -90,7 +90,7 @@ TestNavigator testInternetExplorer({
   appName = ieAppNameTestString,
   vendor = ieVendorTestString,
 }) {
-  return new TestNavigator()
+  return TestNavigator()
     ..userAgent = userAgent
     ..appVersion = appVersion
     ..appName = appName
@@ -103,7 +103,7 @@ TestNavigator testSafari({
   appName = safariAppNameTestString,
   vendor = safariVendorTestString,
 }) {
-  return new TestNavigator()
+  return TestNavigator()
     ..userAgent = userAgent
     ..appVersion = appVersion
     ..appName = appName
@@ -116,7 +116,7 @@ TestNavigator testWkWebView({
   appName = wkWebViewAppNameTestString,
   vendor = wkWebViewVendorTestString,
 }) {
-  return new TestNavigator()
+  return TestNavigator()
     ..userAgent = userAgent
     ..appVersion = appVersion
     ..appName = appName

--- a/test/decorator_test.dart
+++ b/test/decorator_test.dart
@@ -18,7 +18,7 @@ void main() {
 
     void sharedSetup() {
       calls = [];
-      fakeRootNode = new DivElement();
+      fakeRootNode = DivElement();
     }
 
     tearDown(() {
@@ -77,7 +77,7 @@ void main() {
     group('should identify feature support:', () {
       void assertFakeRootNode() {
         if (fakeRootNode == null) {
-          throw new AssertionError(
+          throw AssertionError(
               '`fakeRootNodeClasses` must be set before calling `verifyDistinctFeatureCssClasses`.');
         }
       }
@@ -108,7 +108,7 @@ void main() {
           // 1. Ensure that its there
           expect(
               fakeRootNode.classes,
-              contains(matches(new RegExp(
+              contains(matches(RegExp(
                   '($featureSupportNegationClassPrefix)*${features[i].name}'))));
         }
 
@@ -129,14 +129,14 @@ void main() {
 
       group('custom features provided by the consumer', () {
         Feature uniqueConsumerFeature =
-            new Feature('canvas', new CanvasElement().context2D != null);
+            Feature('canvas', CanvasElement().context2D != null);
         List<Feature> consumerFeaturesThatContainsNoDefaults = [
           uniqueConsumerFeature
         ];
         List<Feature> consumerFeaturesThatMatchesDefaults =
-            new List.from(defaultFeatureCssClassDecorators);
+            List.from(defaultFeatureCssClassDecorators);
         List<Feature> consumerFeaturesThatContainsDefaults =
-            new List.from(defaultFeatureCssClassDecorators)
+            List.from(defaultFeatureCssClassDecorators)
               ..add(uniqueConsumerFeature);
 
         group(
@@ -148,9 +148,8 @@ void main() {
                 rootNode: fakeRootNode,
                 callback: callback);
 
-            verifyFeatureCssClasses(
-                new List.from(defaultFeatureCssClassDecorators)
-                  ..addAll(consumerFeaturesThatContainsNoDefaults));
+            verifyFeatureCssClasses(List.from(defaultFeatureCssClassDecorators)
+              ..addAll(consumerFeaturesThatContainsNoDefaults));
           });
 
           test('and `includeDefaults` is set to `false`', () {

--- a/test/operating_system_test.dart
+++ b/test/operating_system_test.dart
@@ -4,10 +4,10 @@ import 'package:test/test.dart';
 import 'package:platform_detect/src/navigator.dart';
 import 'package:platform_detect/src/operating_system.dart';
 
-final linux = new TestNavigator()..appVersion = 'Linux';
-final mac = new TestNavigator()..appVersion = 'Macintosh';
-final unix = new TestNavigator()..appVersion = 'X11';
-final windows = new TestNavigator()..appVersion = 'Windows';
+final linux = TestNavigator()..appVersion = 'Linux';
+final mac = TestNavigator()..appVersion = 'Macintosh';
+final unix = TestNavigator()..appVersion = 'X11';
+final windows = TestNavigator()..appVersion = 'Windows';
 
 void main() {
   group('operating system detects', () {
@@ -16,7 +16,7 @@ void main() {
     });
 
     test('Unknown Operating System', () {
-      OperatingSystem.navigator = new TestNavigator();
+      OperatingSystem.navigator = TestNavigator();
       var os = OperatingSystem.getCurrentOperatingSystem();
       expect(os.name, OperatingSystem.UnknownOS.name);
       expect(os.isMac, false);


### PR DESCRIPTION
These PRs applies the `dartfmt` and `d1down `scripts to save you some time during phase 2 of Dart 1 removal. Please use it as a starting point to complete the rest of the phase 2 Dart 1 removal steps per the wiki instructions: https://wiki.atl.workiva.net/display/CP/Dart+1+Removal If you already have your own PR in progress, feel free to close this one