### PR TITLE
Widen Dependency Ranges Blocking Dart 2.13

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,12 +8,12 @@ environment:
   sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  meta: ^1.0.4
+  meta: ^1.2.2
   pub_semver: ^2.0.0
 
 dev_dependencies:
   build_runner: ^1.7.1
-  build_test: ^2.0.0
+  build_test: ">=0.10.9 <2.0.0"
   build_web_compilers: ^2.5.1
-  test: ^1.9.1
+  test: ^1.15.7
   workiva_analysis_options: ^1.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^1.7.1
-  build_test: ">=0.10.9 <2.0.0"
+  build_test: ^2.0.0
   build_web_compilers: ^2.5.1
   test: ^1.15.7
   workiva_analysis_options: ^1.0.0


### PR DESCRIPTION
## Motivation
In order for projects to be compatible with Dart 2.13, there are dependencies that need to have their ranges widened. 
For a list of dependencies expected to be changed, see the dependencies section of the Dart 2.12+ [wiki page](https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832).

Another necessary change is the removal of `build_vm_compilers`. If this is the case, additional clean up may need to be done, such as removing the associated config from `build.yaml` or updating how tests are run. A member of Client Platform will be following up with PRs that have CI failures to resolve any issues or perform necessary clean up.

For any questions or concerns, don't hesitate to reach us in the #support-client-plat Slack channel!

## Changes
- Update specific dependencies to be compatible with Dart 2.13.
- Remove `build_vm_compilers` if it was present

## QA
- CI passes

[_Created by Sourcegraph batch change `Workiva/dart_213_dependency_range_widen`._](https://sourcegraph.wk-dev.wdesk.org/organizations/Workiva/batch-changes/dart_213_dependency_range_widen)