### PR TITLE
widen range for pub_semver

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 
 dependencies:
   meta: ^1.0.4
-  pub_semver: ^1.4.2
+  pub_semver: '>=1.4.2 <3.0.0'
 
 dev_dependencies:
   build_runner: ^1.7.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: '>=2.4.0 <3.0.0'
 
 dependencies:
-  meta: ^1.0.4
+  meta: '>=1.0.4 <1.7.0' # Workaround to avoid https://github.com/dart-lang/sdk/issues/46142
   pub_semver: '>=1.4.2 <3.0.0'
 
 dev_dependencies:


### PR DESCRIPTION
This widens the range for pub_semver. It is needed to unblock the use of analyzer 1.0 in over_react.