### PR TITLE
Enable stricter type checks and fix uses of implicit dynamic

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,1 +1,7 @@
 include: package:workiva_analysis_options/v1.yaml
+
+analyzer:
+  language:
+    strict-casts: true
+    strict-inference: true
+    strict-raw-types: true

--- a/example/main.dart
+++ b/example/main.dart
@@ -33,7 +33,7 @@ const String isFirefoxCheckboxId = 'current-is-firefox';
 const String isSafariCheckboxId = 'current-is-safari';
 const String isIeCheckboxId = 'current-is-ie';
 
-main() {
+void main() {
   decorateRootNodeWithPlatformClasses();
 
   _parseCurrentBrowser();

--- a/lib/src/browser.dart
+++ b/lib/src/browser.dart
@@ -21,26 +21,25 @@ class Browser {
 
   static Browser getCurrentBrowser() {
     return _knownBrowsers.firstWhere(
-        (browser) => browser._matchesNavigator(navigator),
+        (browser) => navigator != null && browser._matchesNavigator(navigator!),
         orElse: () => UnknownBrowser);
   }
 
   @visibleForTesting
-  clearVersion() => _version = null;
+  void clearVersion() => _version = null;
 
   static Browser UnknownBrowser =
       Browser('Unknown', (_) => false, (_) => Version(0, 0, 0));
 
-  Browser(this.name, bool this._matchesNavigator(NavigatorProvider navigator),
-      Version this._parseVersion(NavigatorProvider navigator),
+  Browser(this.name, this._matchesNavigator, this._parseVersion,
       {this.className = ''});
 
   final String name;
 
   /// The CSS class value that should be used instead of lowercase [name] (optional).
   final String className;
-  final Function _matchesNavigator;
-  final Function _parseVersion;
+  final bool Function(NavigatorProvider) _matchesNavigator;
+  final Version Function(NavigatorProvider) _parseVersion;
 
   Version? _version;
 

--- a/lib/src/decorator.dart
+++ b/lib/src/decorator.dart
@@ -140,7 +140,7 @@ void decorateRootNodeWithPlatformClasses(
     {List<Feature>? features,
     bool includeDefaults = true,
     Element? rootNode,
-    callback()?}) {
+    void Function()? callback}) {
   rootNode ??= document.documentElement;
 
   if (rootNode != null && !nodeHasBeenDecorated(rootNode)) {

--- a/lib/src/operating_system.dart
+++ b/lib/src/operating_system.dart
@@ -20,17 +20,17 @@ class OperatingSystem {
 
   static OperatingSystem getCurrentOperatingSystem() {
     return _knownSystems.firstWhere(
-        (system) => system._matchesNavigator(navigator),
+        (system) => navigator != null && system._matchesNavigator(navigator!),
         orElse: () => UnknownOS);
   }
 
-  static OperatingSystem UnknownOS = OperatingSystem('Unknown', (n) => false);
+  static OperatingSystem UnknownOS = OperatingSystem('Unknown', (_) => false);
 
   final String name;
-  final Function _matchesNavigator;
+  final bool Function(NavigatorProvider) _matchesNavigator;
 
   OperatingSystem(
-      this.name, bool this._matchesNavigator(NavigatorProvider navigator));
+      this.name, this._matchesNavigator);
 
   static List<OperatingSystem> _knownSystems = [
     chrome,
@@ -40,11 +40,11 @@ class OperatingSystem {
     unix
   ];
 
-  get isLinux => this == linux;
-  get isMac => this == mac;
-  get isUnix => this == unix;
-  get isWindows => this == windows;
-  get isChromeOS => this == chrome;
+  bool get isLinux => this == linux;
+  bool get isMac => this == mac;
+  bool get isUnix => this == unix;
+  bool get isWindows => this == windows;
+  bool get isChromeOS => this == chrome;
 }
 
 OperatingSystem linux = OperatingSystem('Linux', (NavigatorProvider navigator) {

--- a/lib/src/operating_system.dart
+++ b/lib/src/operating_system.dart
@@ -29,8 +29,7 @@ class OperatingSystem {
   final String name;
   final bool Function(NavigatorProvider) _matchesNavigator;
 
-  OperatingSystem(
-      this.name, this._matchesNavigator);
+  OperatingSystem(this.name, this._matchesNavigator);
 
   static List<OperatingSystem> _knownSystems = [
     chrome,

--- a/test/constants.dart
+++ b/test/constants.dart
@@ -46,10 +46,10 @@ const String wkWebViewAppNameTestString = 'Netscape';
 const String wkWebViewVendorTestString = 'Apple Computer, Inc.';
 
 TestNavigator testChrome({
-  userAgent = chromeUserAgentTestString,
-  appVersion = chromeAppVersionTestString,
-  appName = chromeAppNameTestString,
-  vendor = chromeVendorTestString,
+  String userAgent = chromeUserAgentTestString,
+  String appVersion = chromeAppVersionTestString,
+  String appName = chromeAppNameTestString,
+  String vendor = chromeVendorTestString,
 }) {
   return TestNavigator()
     ..userAgent = userAgent
@@ -59,10 +59,10 @@ TestNavigator testChrome({
 }
 
 TestNavigator testChromeless({
-  userAgent = chromelessUserAgentTestString,
-  appVersion = chromelessAppVersionTestString,
-  appName = chromeAppNameTestString,
-  vendor = chromeVendorTestString,
+  String userAgent = chromelessUserAgentTestString,
+  String appVersion = chromelessAppVersionTestString,
+  String appName = chromeAppNameTestString,
+  String vendor = chromeVendorTestString,
 }) {
   return TestNavigator()
     ..userAgent = userAgent
@@ -72,10 +72,10 @@ TestNavigator testChromeless({
 }
 
 TestNavigator testFirefox({
-  userAgent = firefoxUserAgentTestString,
-  appVersion = firefoxAppVersionTestString,
-  appName = firefoxAppNameTestString,
-  vendor = firefoxVendorTestString,
+  String userAgent = firefoxUserAgentTestString,
+  String appVersion = firefoxAppVersionTestString,
+  String appName = firefoxAppNameTestString,
+  String vendor = firefoxVendorTestString,
 }) {
   return TestNavigator()
     ..userAgent = userAgent
@@ -85,10 +85,10 @@ TestNavigator testFirefox({
 }
 
 TestNavigator testInternetExplorer({
-  userAgent = ieUserAgentTestString,
-  appVersion = ieAppVersionTestString,
-  appName = ieAppNameTestString,
-  vendor = ieVendorTestString,
+  String userAgent = ieUserAgentTestString,
+  String appVersion = ieAppVersionTestString,
+  String appName = ieAppNameTestString,
+  String vendor = ieVendorTestString,
 }) {
   return TestNavigator()
     ..userAgent = userAgent
@@ -98,10 +98,10 @@ TestNavigator testInternetExplorer({
 }
 
 TestNavigator testSafari({
-  userAgent = safariUserAgentTestString,
-  appVersion = safariAppVersionTestString,
-  appName = safariAppNameTestString,
-  vendor = safariVendorTestString,
+  String userAgent = safariUserAgentTestString,
+  String appVersion = safariAppVersionTestString,
+  String appName = safariAppNameTestString,
+  String vendor = safariVendorTestString,
 }) {
   return TestNavigator()
     ..userAgent = userAgent
@@ -111,10 +111,10 @@ TestNavigator testSafari({
 }
 
 TestNavigator testWkWebView({
-  userAgent = wkWebViewUserAgentTestString,
-  appVersion = wkWebViewAppVersionTestString,
-  appName = wkWebViewAppNameTestString,
-  vendor = wkWebViewVendorTestString,
+  String userAgent = wkWebViewUserAgentTestString,
+  String appVersion = wkWebViewAppVersionTestString,
+  String appName = wkWebViewAppNameTestString,
+  String vendor = wkWebViewVendorTestString,
 }) {
   return TestNavigator()
     ..userAgent = userAgent

--- a/test/decorator_test.dart
+++ b/test/decorator_test.dart
@@ -10,7 +10,7 @@ import 'package:platform_detect/src/support.dart';
 void main() {
   group('root node CSS class injection', () {
     late Element fakeRootNode;
-    late List calls;
+    late List<String> calls;
 
     void callback() {
       calls.add('callback');


### PR DESCRIPTION
Declare explciit types for cases where they won't be inferred so that
they won't be implicitly `dynamic`.