### PR TITLE
Allow newer build dependencies

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,6 @@ dependencies:
 dev_dependencies:
   build_runner: '>=1.7.1 <3.0.0'
   build_test: ^2.0.0
-  build_web_compilers: ^2.5.1
+  build_web_compilers: '>=2.5.1 <4.0.0'
   test: ^1.15.7
   workiva_analysis_options: ^1.0.0


### PR DESCRIPTION
Summary
---
Frontend Frameworks is updating dependencies! More details at
https://wiki.atl.workiva.net/display/CP/Dependency+Upgrades

This PR gets us closer to unblocking analyzer 2+ by allowing these new versions
once we upgrade built_redux, over_react, and handle json_serializable.

It raises the maximum for these packages:
- build_web_compilers
- build_test
- build_runner

For more info, reach out to `#support-frontend-dx` on Slack.

[_Created by Sourcegraph batch change `Workiva/newer_build_dev_deps`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/newer_build_dev_deps)