### PR TITLE
Update dev dependencies for analyzer 2

### DIFF
--- a/.github/workflows/dart_ci.yaml
+++ b/.github/workflows/dart_ci.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        sdk: [ stable, beta ]
+        sdk: [ 2.18.7, 2.19.6, stable ]
     steps:
       - uses: actions/checkout@v2
       - uses: dart-lang/setup-dart@v1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,8 +12,8 @@ dependencies:
   pub_semver: ^2.0.0
 
 dev_dependencies:
-  build_runner: '>=1.7.1 <3.0.0'
+  build_runner: ^2.0.0
   build_test: ^2.0.0
-  build_web_compilers: '>=2.5.1 <4.0.0'
+  build_web_compilers: ^3.0.0
   test: ^1.15.7
   workiva_analysis_options: ^1.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,5 +15,5 @@ dev_dependencies:
   build_runner: ^2.0.0
   build_test: ^2.0.0
   build_web_compilers: ^3.0.0
-  test: ^1.15.7
-  workiva_analysis_options: ^1.0.0
+  test: ^1.16.0
+  workiva_analysis_options: ^1.2.0


### PR DESCRIPTION
Summary
---
Frontend Frameworks is updating dependencies! Now that we can resolve to analyzer 2
we can raise the minimums of many dependencies were ranged to support both 
analyzer 1 and 2.

```
  pubspec_codemod raise-min analyzer 2.0.0 --recursive
  pubspec_codemod raise-min dependency_validator 3.0.0 --recursive
  pubspec_codemod raise-min test_html_builder 3.0.0 --recursive
  pubspec_codemod raise-min dart_style 2.0.0 --recursive
  pubspec_codemod raise-min build_web_compilers 3.0.0 --recursive
  pubspec_codemod raise-min build_test 2.0.0 --recursive
  pubspec_codemod raise-min build_runner 2.0.0 --recursive
  pubspec_codemod raise-min w_common 3.0.0 --recursive
  pubspec_codemod raise-min w_common_tools 3.0.0 --recursive
  pubspec_codemod raise-min uuid 3.0.0 --recursive
  pubspec_codemod raise-min fluri 2.0.0 --recursive
  pubspec_codemod raise-min get_it 6.0.0 --recursive
  pubspec_codemod raise-min dart_dev 4.0.0 --recursive
```

A passing CI is sufficient QA (that means dependencies resolve and tests run and pass).

For question or concerns visit `#support-frontend-dx`

[_Created by Sourcegraph batch change `Workiva/update_dev_deps_analyzer2`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/update_dev_deps_analyzer2)