### PR TITLE
Avoid meta 1.10.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  meta: ^1.6.0
+  meta: '>=1.6.0  <1.10.0'
   pub_semver: ^2.0.0
 
 dev_dependencies:
@@ -17,3 +17,6 @@ dev_dependencies:
   build_web_compilers: '>=2.5.1 <4.0.0'
   test: ^1.15.7
   workiva_analysis_options: ^1.0.0
+dependency_validator:
+  ignore:
+    - meta


### PR DESCRIPTION
Summary
---
This is a batch change to apply a dependency range pin to the meta package
in order to avoid a "bad release". That version causes nearly all of our builds to
fail (anything on analyzer < 5).
So restricting the version range to <1.10.0 works around the issue until we
can upgrade to analyzer 5.

For more info, visit `#lang-dart` in Slack.

[_Created by Sourcegraph batch change `Workiva/avoid_meta_1_10_0`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/avoid_meta_1_10_0)