### PR TITLE
FED-2880 Fix Blink-based Microsoft Edge Browser Detection

### DIFF
--- a/.github/workflows/dart_ci.yaml
+++ b/.github/workflows/dart_ci.yaml
@@ -30,6 +30,7 @@ jobs:
       - name: Run tests
         run: dart test
       - uses: anchore/sbom-action@v0
+        if: ${{ matrix.sdk == '2.19.6' }}
         with:
           path: ./
           format: cyclonedx-json

--- a/test/browser_test.dart
+++ b/test/browser_test.dart
@@ -95,6 +95,7 @@ void main() {
 
         expect(browser.name, 'Safari');
         expect(browser.isChrome, false);
+        expect(browser.isEdgeChrome, isFalse);
         expect(browser.isFirefox, false);
         expect(browser.isSafari, true);
         expect(browser.isInternetExplorer, false);
@@ -110,6 +111,7 @@ void main() {
 
         expect(browser.name, 'Safari');
         expect(browser.isChrome, false);
+        expect(browser.isEdgeChrome, isFalse);
         expect(browser.isFirefox, false);
         expect(browser.isSafari, true);
         expect(browser.isInternetExplorer, false);
@@ -125,6 +127,7 @@ void main() {
 
         expect(browser.name, 'Safari');
         expect(browser.isChrome, false);
+        expect(browser.isEdgeChrome, isFalse);
         expect(browser.isFirefox, false);
         expect(browser.isSafari, true);
         expect(browser.isInternetExplorer, false);
@@ -138,6 +141,7 @@ void main() {
 
       expect(browser.name, 'WKWebView');
       expect(browser.isChrome, false);
+      expect(browser.isEdgeChrome, isFalse);
       expect(browser.isFirefox, false);
       expect(browser.isSafari, false);
       expect(browser.isWKWebView, true);

--- a/test/browser_test.dart
+++ b/test/browser_test.dart
@@ -21,6 +21,7 @@ void main() {
       expect(browser.name, Browser.UnknownBrowser.name);
       expect(browser.version, Browser.UnknownBrowser.version);
       expect(browser.isChrome, false);
+      expect(browser.isEdgeChrome, isFalse);
       expect(browser.isFirefox, false);
       expect(browser.isSafari, false);
       expect(browser.isInternetExplorer, false);
@@ -31,6 +32,7 @@ void main() {
       expect(browser.name, 'Fake');
       expect(browser.version, Version(1, 1, 0));
       expect(browser.isChrome, false);
+      expect(browser.isEdgeChrome, isFalse);
       expect(browser.isFirefox, false);
       expect(browser.isSafari, false);
       expect(browser.isInternetExplorer, false);
@@ -42,10 +44,33 @@ void main() {
 
       expect(browser.name, 'Chrome');
       expect(browser.isChrome, true);
+      expect(browser.isEdgeChrome, isFalse);
       expect(browser.isFirefox, false);
       expect(browser.isSafari, false);
       expect(browser.isInternetExplorer, false);
       expect(browser.version, Version(53, 0, 2785, build: '143'));
+    });
+
+    test('Edge Chrome', () {
+      Browser.navigator = testChromeEdge();
+      browser = Browser.getCurrentBrowser();
+
+      expect(browser.name, 'Edge');
+      expect([browser.isChrome, browser.isEdgeChrome], everyElement(isTrue),
+          reason:
+              'Blink-based Edge browser should be detected as both Chrome and Edge '
+              'since feature support is based on Chrome, but should identify as Edge '
+              'for logging purposes');
+      expect(browser.isFirefox, isFalse);
+      expect(browser.isSafari, isFalse);
+      expect(browser.isInternetExplorer, isFalse);
+      expect(browser.version, Version(91, 0, 864, build: '59'));
+
+      expect(browser, isA<EdgeChrome>());
+      expect(
+        (browser as EdgeChrome).chromeVersion,
+        Version(91, 0, 4472, build: '124'),
+      );
     });
 
     test('Chromeless', () {
@@ -54,6 +79,7 @@ void main() {
 
       expect(browser.name, 'Chrome');
       expect(browser.isChrome, true);
+      expect(browser.isEdgeChrome, isFalse);
       expect(browser.isFirefox, false);
       expect(browser.isSafari, false);
       expect(browser.isInternetExplorer, false);
@@ -66,10 +92,24 @@ void main() {
 
       expect(browser.name, 'Internet Explorer');
       expect(browser.isChrome, false);
+      expect(browser.isEdgeChrome, isFalse);
       expect(browser.isFirefox, false);
       expect(browser.isSafari, false);
       expect(browser.isInternetExplorer, true);
       expect(browser.version, Version(11, 0, 0));
+    });
+
+    test('Internet Explorer (Edge)', () {
+      Browser.navigator = testInternetExplorerEdge();
+      browser = Browser.getCurrentBrowser();
+
+      expect(browser.name, 'Internet Explorer');
+      expect(browser.isChrome, isFalse);
+      expect(browser.isEdgeChrome, isFalse);
+      expect(browser.isFirefox, isFalse);
+      expect(browser.isSafari, isFalse);
+      expect(browser.isInternetExplorer, isTrue);
+      expect(browser.version, Version(12, 10136, 0));
     });
 
     test('Firefox', () {
@@ -78,6 +118,7 @@ void main() {
 
       expect(browser.name, 'Firefox');
       expect(browser.isChrome, false);
+      expect(browser.isEdgeChrome, isFalse);
       expect(browser.isFirefox, true);
       expect(browser.isSafari, false);
       expect(browser.isInternetExplorer, false);

--- a/test/constants.dart
+++ b/test/constants.dart
@@ -23,6 +23,11 @@ const String ieAppVersionTestString =
 const String ieAppNameTestString = 'Netscape';
 const String ieVendorTestString = 'Microsoft';
 
+const String ieEdgeUserAgentTestString =
+    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.10136';
+const String ieEdgeAppVersionTestString =
+    '5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.10136';
+
 const String safariUserAgentTestString =
     'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/601.7.8 (KHTML, like Gecko) Version/9.1.3 Safari/601.7.8';
 const String safariAppVersionTestString =
@@ -96,6 +101,11 @@ TestNavigator testInternetExplorer({
     ..appName = appName
     ..vendor = vendor;
 }
+
+TestNavigator testInternetExplorerEdge() => testInternetExplorer(
+      userAgent: ieEdgeUserAgentTestString,
+      appVersion: ieEdgeAppVersionTestString,
+    );
 
 TestNavigator testSafari({
   String userAgent = safariUserAgentTestString,

--- a/test/constants.dart
+++ b/test/constants.dart
@@ -28,6 +28,12 @@ const String ieEdgeUserAgentTestString =
 const String ieEdgeAppVersionTestString =
     '5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.10136';
 
+/// See: <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent#microsoft_edge_ua_string>
+const String chromeEdgeUserAgentTestString =
+    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36 Edg/91.0.864.59';
+const String chromeEdgeAppVersionTestString =
+    '5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36 Edg/91.0.864.59';
+
 const String safariUserAgentTestString =
     'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/601.7.8 (KHTML, like Gecko) Version/9.1.3 Safari/601.7.8';
 const String safariAppVersionTestString =
@@ -62,6 +68,11 @@ TestNavigator testChrome({
     ..appName = appName
     ..vendor = vendor;
 }
+
+TestNavigator testChromeEdge() => testChrome(
+      userAgent: chromeEdgeUserAgentTestString,
+      appVersion: chromeEdgeAppVersionTestString,
+    );
 
 TestNavigator testChromeless({
   String userAgent = chromelessUserAgentTestString,


### PR DESCRIPTION
Currently, the modern Edge browser gets detected as `Chrome` - which is not ideal for logging purposes.

The browser - from a feature-set standpoint - literally IS `Chrome` - so it should remain being detected as such, but its name/version should reflect the application itself - not just the platform it is built atop of.

---

Also boy scouted some missing test coverage for the legacy (MSIE-based) Edge browser.